### PR TITLE
Add error attribute for access to thrown exceptions

### DIFF
--- a/lib/lotus/action/throwable.rb
+++ b/lib/lotus/action/throwable.rb
@@ -111,6 +111,11 @@ module Lotus
         self.body   = message
       end
 
+      # The exception raised during call (if any)
+      def error
+        @_error
+      end
+
       private
       def _rescue
         catch :halt do
@@ -123,6 +128,7 @@ module Lotus
       end
 
       def _handle_exception(exception)
+        @_error = exception
         throw self.class.handled_exceptions.fetch(exception.class, 500)
       end
     end

--- a/test/throw_test.rb
+++ b/test/throw_test.rb
@@ -89,5 +89,11 @@ describe Lotus::Action do
       response[0].must_equal 408
       response[2].must_equal ['Request Timeout']
     end
+
+    it 'provides access to the exception via error attribute' do
+      action = ErrorCallAction.new
+      response = action.call({})
+      action.send(:error).class.must_equal RuntimeError
+    end
   end
 end


### PR DESCRIPTION
Currently exceptions are converted to http status codes and the exception is swallowed.  I might be missing something, but I need access to the exception.  Let me know if you'd rather see the API implemented differently.

btw, lotus looks stellar and the performance with ruby 2.1.1 is inline with nodejs
