### PR TITLE
Allow exception handling to be disabled

### DIFF
--- a/lib/lotus/action/throwable.rb
+++ b/lib/lotus/action/throwable.rb
@@ -37,6 +37,19 @@ module Lotus
             # @see Lotus::Action::Throwable.handle_exception
             class_attribute :handled_exceptions
             self.handled_exceptions = Controller.handled_exceptions.dup
+
+            # Action-level setting for handling exceptions.
+            #
+            # When an exception is raised during a #call execution it will be
+            # translated into an associated HTTP status by default. You may
+            # want to disable this behavior for your testes.
+            #
+            # @api private
+            # @since 0.2.0
+            #
+            # @see Lotus::Controller.handle_exceptions
+            class_attribute :handle_exceptions
+            self.handle_exceptions = Controller.handle_exceptions
           end
         end
 
@@ -123,6 +136,7 @@ module Lotus
       end
 
       def _handle_exception(exception)
+        raise unless self.class.handle_exceptions
         throw self.class.handled_exceptions.fetch(exception.class, 500)
       end
     end

--- a/lib/lotus/controller.rb
+++ b/lib/lotus/controller.rb
@@ -60,6 +60,37 @@ module Lotus
     class_attribute :handled_exceptions
     self.handled_exceptions = {}
 
+    # Global setting for handling exceptions.
+    #
+    # When an exception is raised during a #call execution it will be
+    # translated into an associated HTTP status by default. You may want to
+    # disable this behavior for your testes.
+    #
+    # **Important:** Be sure to set this configuration, **before** the actions
+    # and controllers of your application are loaded.
+    #
+    # @since 0.2.0
+    #
+    # @see Lotus::Action::Throwable
+    #
+    # @example
+    #   require 'lotus/controller'
+    #
+    #   Lotus::Controller.handle_exceptions = false
+    #
+    #   class Show
+    #     include Lotus::Action
+    #
+    #     def call(params)
+    #       # ...
+    #       raise RecordNotFound.new
+    #     end
+    #   end
+    #
+    #   Show.new.call({id: 1}) # => ERROR RecordNotFound: RecordNotFound
+    class_attribute :handle_exceptions
+    self.handle_exceptions = true
+
     def self.included(base)
       base.class_eval do
         include Dsl

--- a/test/action_test.rb
+++ b/test/action_test.rb
@@ -16,6 +16,22 @@ describe Lotus::Action do
       response[0].must_equal 500
       response[2].must_equal ['Internal Server Error']
     end
+
+    describe 'when exception handling code is disabled' do
+      before do
+        ErrorCallAction.handle_exceptions = false
+      end
+
+      after do
+        ErrorCallAction.handle_exceptions = true
+      end
+
+      it 'should raise an actual exception' do
+        proc {
+          ErrorCallAction.new.call({})
+        }.must_raise RuntimeError
+      end
+    end
   end
 
   describe '#expose' do


### PR DESCRIPTION
The default exception handling is very inconvenient while developing and testing a controller as it may hide difficult to spot mistakes behind a very generic 500 error. A solution proposed in #5 would help in development, but not when writing tests.

An afterthought: `handle_exceptions` is very similar to the `handled_exceptions` attribute and `handle_exception` method of `Lotus::Action::Throwable` so it may cause unintentional problems with typos. I'll gladly fix the PR if any better name is suggested.
