### PR TITLE
Reduce method visibility where possible

### DIFF
--- a/lib/lotus/action.rb
+++ b/lib/lotus/action.rb
@@ -54,7 +54,7 @@ module Lotus
       end
     end
 
-    protected
+    private
 
     # Finalize the response
     #

--- a/lib/lotus/action/callable.rb
+++ b/lib/lotus/action/callable.rb
@@ -75,7 +75,7 @@ module Lotus
         finish
       end
 
-      protected
+      private
 
       # Prepare the Rack response before the control is returned to the
       # webserver.

--- a/lib/lotus/action/configurable.rb
+++ b/lib/lotus/action/configurable.rb
@@ -39,7 +39,8 @@ module Lotus
         config.load!(base)
       end
 
-      protected
+      private
+
       def configuration
         self.class.configuration
       end

--- a/lib/lotus/action/cookies.rb
+++ b/lib/lotus/action/cookies.rb
@@ -10,8 +10,7 @@ module Lotus
     #
     # @see Lotus::Action::Cookies#cookies
     module Cookies
-
-      protected
+      private
 
       # Finalize the response by flushing cookies into the response
       #

--- a/lib/lotus/action/mime.rb
+++ b/lib/lotus/action/mime.rb
@@ -50,7 +50,7 @@ module Lotus
             raise Lotus::Controller::UnknownFormatError.new(format)
         end
 
-        protected
+        private
 
         # Restrict the access to the specified mime type symbols.
         #
@@ -176,7 +176,8 @@ module Lotus
         @content_type || accepts || default_content_type || DEFAULT_CONTENT_TYPE
       end
 
-      protected
+      private
+
       # Finalize the response by setting the current content type
       #
       # @since 0.1.0

--- a/lib/lotus/action/rack.rb
+++ b/lib/lotus/action/rack.rb
@@ -90,6 +90,31 @@ module Lotus
       end
 
       protected
+
+      # Gets the headers from the response
+      #
+      # @return [Hash] the HTTP headers from the response
+      #
+      # @since 0.1.0
+      #
+      # @example
+      #   require 'lotus/controller'
+      #
+      #   class Show
+      #     include Lotus::Action
+      #
+      #     def call(params)
+      #       # ...
+      #       self.headers            # => { ... }
+      #       self.headers.merge!({'X-Custom' => 'OK'})
+      #     end
+      #   end
+      def headers
+        @headers
+      end
+
+      private
+
       # Sets the HTTP status code for the response
       #
       # @param status [Fixnum] an HTTP status code
@@ -133,28 +158,6 @@ module Lotus
       def body=(body)
         body   = Array(body) unless body.respond_to?(:each)
         @_body = body
-      end
-
-      # Gets the headers from the response
-      #
-      # @return [Hash] the HTTP headers from the response
-      #
-      # @since 0.1.0
-      #
-      # @example
-      #   require 'lotus/controller'
-      #
-      #   class Show
-      #     include Lotus::Action
-      #
-      #     def call(params)
-      #       # ...
-      #       self.headers            # => { ... }
-      #       self.headers.merge!({'X-Custom' => 'OK'})
-      #     end
-      #   end
-      def headers
-        @headers
       end
 
       # Returns a serialized Rack response (Array), according to the current

--- a/lib/lotus/action/redirect.rb
+++ b/lib/lotus/action/redirect.rb
@@ -10,7 +10,7 @@ module Lotus
       # @api private
       LOCATION = 'Location'.freeze
 
-      protected
+      private
 
       # Redirect to the given URL
       #

--- a/lib/lotus/action/session.rb
+++ b/lib/lotus/action/session.rb
@@ -12,7 +12,7 @@ module Lotus
       # @api private
       SESSION_KEY = 'rack.session'.freeze
 
-      protected
+      private
 
       # Gets the session from the request and expose it as an Hash.
       #

--- a/lib/lotus/action/throwable.rb
+++ b/lib/lotus/action/throwable.rb
@@ -20,7 +20,7 @@ module Lotus
       end
 
       module ClassMethods
-        protected
+        private
 
         # Handle the given exception with an HTTP status code.
         #

--- a/lib/lotus/controller/configuration.rb
+++ b/lib/lotus/controller/configuration.rb
@@ -500,6 +500,7 @@ module Lotus
       end
 
       protected
+
       attr_accessor :handled_exceptions
       attr_accessor :formats
       attr_writer :action_module


### PR DESCRIPTION
Many methods that were marked as `protected` didn't actually need to be so. 
This commit reduces the visibility level of these methods to `private` as 
possible.
