### PR TITLE
Fix grammar errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ action.call({}) # => [401, {}, ["Unauthorized"]]
 
 It offers convenient access to cookies.
 
-They are read as an Hash from Rack env:
+They are read as a Hash from Rack env:
 
 ```ruby
 require 'lotus/controller'
@@ -370,7 +370,7 @@ action = ReadCookiesFromRackEnv.new
 action.call({'HTTP_COOKIE' => 'foo=bar'})
 ```
 
-They are set like an Hash:
+They are set like a Hash:
 
 ```ruby
 require 'lotus/controller'
@@ -432,7 +432,7 @@ action = ReadSessionFromRackEnv.new
 action.call({ 'rack.session' => { 'age' => '31' }})
 ```
 
-Values can be set like an Hash:
+Values can be set like a Hash:
 
 ```ruby
 require 'lotus/controller'
@@ -452,7 +452,7 @@ action = SetSession.new
 action.call({}) # => [200, {"Set-Cookie"=>"rack.session=..."}, "..."]
 ```
 
-Values can be removed like an Hash:
+Values can be removed like a Hash:
 
 ```ruby
 require 'lotus/controller'


### PR DESCRIPTION
Hello!

`an Hash` is not correct.

You put `an` before vowels that is correct and also before words that starts with `h` with some exceptions.

If the `h` is unsounded use `an` like:

`an honorable library`
`an hour`

In both, they `h` doesn't sound but:

`a Hash`
`a Home`
`a Horse`

Those `h` does sound so you put an `a`. There are more rules but meh, this is Ruby, not English grammar.

Anyway, keep the hard work, lovely framework.
