### PR TITLE
Fix Action for requests that contains different mime types

### DIFF
--- a/lib/lotus/action/mime.rb
+++ b/lib/lotus/action/mime.rb
@@ -140,7 +140,7 @@ module Lotus
       #   headers['Content-Type'] # => 'application/xml'
       #   action.format           # => :xml
       def format
-        @format ||= detect_format
+        @format || detect_format
       end
 
       # The content type that will be automatically set in the response.
@@ -344,7 +344,7 @@ module Lotus
       # @since 0.1.0
       # @api private
       def accept
-        @accept ||= @_env[HTTP_ACCEPT] || DEFAULT_ACCEPT
+        @accept || @_env[HTTP_ACCEPT] || DEFAULT_ACCEPT
       end
 
       # @since 0.1.0

--- a/test/action/format_test.rb
+++ b/test/action/format_test.rb
@@ -47,6 +47,20 @@ describe Lotus::Action do
       status.must_equal                   200
     end
 
+    it "returns detected mime type when it is not specified explicitly" do
+      status, headers, _ = @action.call({ 'HTTP_ACCEPT' => 'text/html' })
+
+      @action.format.must_equal    :html
+      headers['Content-Type'].must_equal 'text/html'
+      status.must_equal                   200
+
+      status, headers, _ = @action.call({ 'HTTP_ACCEPT' => 'application/xml' })
+
+      @action.format.must_equal    :xml
+      headers['Content-Type'].must_equal 'application/xml'
+      status.must_equal                   200
+    end
+
     mime_types = ['application/octet-stream', 'text/html']
     Rack::Mime::MIME_TYPES.each do |format, mime_type|
       next if mime_types.include?(mime_type)


### PR DESCRIPTION
Hi.

Today, `Action#forma`t returns same value even if it received requests that contains different mime types.
(see also https://github.com/lotus/view/issues/32)
Because, it make cache of format in `@format` and `@accept`.

This PR fix its behavior, but let me know if someone have more beautiful solution.

Thanks.
