### PR TITLE
Charset setting support

### DIFF
--- a/lib/lotus/controller/configuration.rb
+++ b/lib/lotus/controller/configuration.rb
@@ -391,7 +391,7 @@ module Lotus
       # requirement for the mime type.
       #
       # The given format must be coercible to a symbol, and be a valid mime type
-      # alias. If it isn't, at the runtime the framework will raise a 
+      # alias. If it isn't, at the runtime the framework will raise a
       # `Lotus::Controller::UnknownFormatError`.
       #
       # By default this value is nil.
@@ -429,6 +429,34 @@ module Lotus
           @default_format = Utils::Kernel.Symbol(format)
         else
           @default_format
+        end
+      end
+
+      # Set a charset as default fallback for all the requests without a strict
+      # requirement for the charset.
+      #
+      # By default this value is nil.
+      #
+      # @since 0.2.0
+      #
+      # @see Lotus::Action::Mime
+      #
+      # @example Getting the value
+      #   require 'lotus/controller'
+      #
+      #   Lotus::Controller.configuration.default_charset # => nil
+      #
+      # @example Setting the value
+      #   require 'lotus/controller'
+      #
+      #   Lotus::Controller.configure do
+      #     default_charset 'koi8-r'
+      #   end
+      def default_charset(charset = nil)
+        if charset
+          @default_charset = charset
+        else
+          @default_charset
         end
       end
 

--- a/test/action/format_test.rb
+++ b/test/action/format_test.rb
@@ -27,7 +27,7 @@ describe Lotus::Action do
       status, headers, _ = @action.call({})
 
       @action.format.must_equal   :all
-      headers['Content-Type'].must_equal 'application/octet-stream'
+      headers['Content-Type'].must_equal 'application/octet-stream; charset=utf-8'
       status.must_equal                  200
     end
 
@@ -35,7 +35,7 @@ describe Lotus::Action do
       status, headers, _ = @action.call({ 'HTTP_ACCEPT' => 'text/html' })
 
       @action.format.must_equal    :html
-      headers['Content-Type'].must_equal 'text/html'
+      headers['Content-Type'].must_equal 'text/html; charset=utf-8'
       status.must_equal                   200
     end
 
@@ -43,7 +43,7 @@ describe Lotus::Action do
       status, headers, _ = @action.call({ 'HTTP_ACCEPT' => 'application/unknown' })
 
       @action.format.must_equal    :all
-      headers['Content-Type'].must_equal 'application/octet-stream'
+      headers['Content-Type'].must_equal 'application/octet-stream; charset=utf-8'
       status.must_equal                   200
     end
 
@@ -58,7 +58,7 @@ describe Lotus::Action do
         status, headers, _ = @action.call({ 'HTTP_ACCEPT' => mime_type })
 
         @action.format.must_equal   format
-        headers['Content-Type'].must_equal mime_type
+        headers['Content-Type'].must_equal "#{mime_type}; charset=utf-8"
         status.must_equal                  200
       end
     end
@@ -73,7 +73,7 @@ describe Lotus::Action do
       status, headers, _ = @action.call({ format: 'all' })
 
       @action.format.must_equal   :all
-      headers['Content-Type'].must_equal 'application/octet-stream'
+      headers['Content-Type'].must_equal 'application/octet-stream; charset=utf-8'
       status.must_equal                  200
     end
 
@@ -105,7 +105,7 @@ describe Lotus::Action do
         _, headers, _ = @action.call({ format: format })
 
         @action.format.must_equal   format.to_sym
-        headers['Content-Type'].must_equal mime_type
+        headers['Content-Type'].must_equal "#{mime_type}; charset=utf-8"
       end
     end
   end

--- a/test/action_test.rb
+++ b/test/action_test.rb
@@ -26,7 +26,7 @@ describe Lotus::Action do
       response = CallAction.new.call({})
 
       response[0].must_equal 201
-      response[1].must_equal({'Content-Type' => 'application/octet-stream', 'X-Custom' => 'OK'})
+      response[1].must_equal({'Content-Type' => 'application/octet-stream; charset=utf-8', 'X-Custom' => 'OK'})
       response[2].must_equal ['Hi from TestAction!']
     end
 

--- a/test/cookies_test.rb
+++ b/test/cookies_test.rb
@@ -14,7 +14,7 @@ describe Lotus::Action do
       response = action.call({'HTTP_COOKIE' => 'foo=bar'})
 
       action.send(:cookies).must_include({foo: 'bar'})
-      response[1].must_equal({'Content-Type' => 'application/octet-stream', 'Set-Cookie' => 'foo=bar'})
+      response[1].must_equal({'Content-Type' => 'application/octet-stream; charset=utf-8', 'Set-Cookie' => 'foo=bar'})
       response[2].must_equal ['bar']
     end
 
@@ -23,7 +23,7 @@ describe Lotus::Action do
       response = action.call({})
 
       response[2].must_equal(['yo'])
-      response[1].must_equal({'Content-Type' => 'application/octet-stream', 'Set-Cookie' => 'foo=yum%21'})
+      response[1].must_equal({'Content-Type' => 'application/octet-stream; charset=utf-8', 'Set-Cookie' => 'foo=yum%21'})
     end
 
     it 'sets cookies with options' do
@@ -31,14 +31,14 @@ describe Lotus::Action do
       action   = SetCookiesWithOptionsAction.new
       response = action.call({expires: tomorrow})
 
-      response[1].must_equal({'Content-Type' => 'application/octet-stream', 'Set-Cookie' => "kukki=yum%21; domain=lotusrb.org; path=/controller; expires=#{ tomorrow.gmtime.rfc2822 }; secure; HttpOnly"})
+      response[1].must_equal({'Content-Type' => 'application/octet-stream; charset=utf-8', 'Set-Cookie' => "kukki=yum%21; domain=lotusrb.org; path=/controller; expires=#{ tomorrow.gmtime.rfc2822 }; secure; HttpOnly"})
     end
 
     it 'removes cookies' do
       action   = RemoveCookiesAction.new
       response = action.call({'HTTP_COOKIE' => 'foo=bar;rm=me'})
 
-      response[1].must_equal({'Content-Type' => 'application/octet-stream', 'Set-Cookie' => "foo=bar\nrm=; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 -0000"})
+      response[1].must_equal({'Content-Type' => 'application/octet-stream; charset=utf-8', 'Set-Cookie' => "foo=bar\nrm=; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 -0000"})
     end
   end
 end

--- a/test/redirect_test.rb
+++ b/test/redirect_test.rb
@@ -7,7 +7,7 @@ describe Lotus::Action do
       response = action.call({})
 
       response[0].must_equal(302)
-      response[1].must_equal({ 'Content-Type' => 'application/octet-stream', 'Location' => '/destination' })
+      response[1].must_equal({ 'Content-Type' => 'application/octet-stream; charset=utf-8', 'Location' => '/destination' })
     end
 
     it 'redirects with custom status code' do


### PR DESCRIPTION
Rails returns "Content-Type: text/html; charset=utf-8"
and for Lotus it’s just "Content-Type: text/html"
it may be a problem with some languages like Russian
