### PR TITLE
Flash enumeration

### DIFF
--- a/lib/lotus/action/flash.rb
+++ b/lib/lotus/action/flash.rb
@@ -1,3 +1,5 @@
+require 'forwardable'
+
 module Lotus
   module Action
     # Container useful to transport data with the HTTP session
@@ -6,6 +8,11 @@ module Lotus
     # @since x.x.x
     # @api private
     class Flash
+      extend Forwardable
+
+      # Delegate iteration to the underlying data storage
+      def_delegator :data, :each, :each
+
       # Session key where the data is stored
       #
       # @since x.x.x

--- a/test/action/flash_test.rb
+++ b/test/action/flash_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+describe Lotus::Action::Flash do
+  let (:flash) { Lotus::Action::Flash.new({},12312) }
+
+  it '#each returns Enumerable' do
+    assert_kind_of Enumerator, flash.each
+  end
+
+  describe 'iteration' do
+
+    it '#each yields all flashes to the block' do
+      flash[:success], flash[:error] = 'Success', 'Error'
+      accum = []
+      flash.each { |k, v| accum << { :"#{k}".to_sym =>  v} }
+      assert_equal accum, [{success: 'Success'}, {error: 'Error'}]
+    end
+
+    after { flash.clear }
+  end
+end


### PR DESCRIPTION
The idea is to allow to cycle over the flashes in the template 

``` erb
  <body>
    <% flash.each do |name, msg| -%>
      <%= content_tag :div, msg, class: name %>
    <% end -%>
```

this code will allow to iterate only through data associated with the current request, so maybe it need additional work.
