### PR TITLE
Use more inclusive terms in docs/code

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,10 +135,10 @@ action   = Show.new(configuration: configuration)
 response = action.call(id: 23, key: "value")
 ```
 
-#### Whitelisting
+#### Allowlisting
 
 Params represent an untrusted input.
-For security reasons it's recommended to whitelist them.
+For security reasons it's recommended to allowlist them.
 
 ```ruby
 require "hanami/validations"
@@ -162,11 +162,11 @@ class Signup < Hanami::Action
     puts request.params.class            # => Signup::Params
     puts request.params.class.superclass # => Hanami::Action::Params
 
-    # Whitelist :first_name, but not :admin
+    # Allowlist :first_name, but not :admin
     puts request.params[:first_name]     # => "Luca"
     puts request.params[:admin]          # => nil
 
-    # Whitelist nested params [:address][:line_one], not [:address][:line_two]
+    # Allowlist nested params [:address][:line_one], not [:address][:line_two]
     puts request.params[:address][:line_one] # => "69 Tender St"
     puts request.params[:address][:line_two] # => nil
   end

--- a/spec/integration/hanami/controller/routing_spec.rb
+++ b/spec/integration/hanami/controller/routing_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe "Hanami::Router integration" do
     end
 
     context "with validations" do
-      it "automatically whitelists params from router" do
+      it "automatically allowlist params from router" do
         response = app.request("PATCH", "/painters/23", params: {painter: {first_name: "Gustav", last_name: "Klimt"}})
 
         expect(response.status).to be(200)

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -599,7 +599,7 @@ class ParamsAction < Hanami::Action
   end
 end
 
-class WhitelistedParamsAction < Hanami::Action
+class AllowlistedParamsAction < Hanami::Action
   class Params < Hanami::Action::Params
     params do
       if RSpec::Support::Validations.version?(2)
@@ -621,7 +621,7 @@ class WhitelistedParamsAction < Hanami::Action
   end
 end
 
-class WhitelistedDslAction < Hanami::Action
+class AllowlistedDslAction < Hanami::Action
   params do
     required(:username).filled
   end
@@ -631,7 +631,7 @@ class WhitelistedDslAction < Hanami::Action
   end
 end
 
-class WhitelistedUploadDslAction < Hanami::Action
+class AllowlistedUploadDslAction < Hanami::Action
   params do
     if RSpec::Support::Validations.version?(2)
       required(:id).maybe(:integer)
@@ -1975,7 +1975,7 @@ end
 class DependencyContractAction < ContractActionBase
 end
 
-class WhitelistedUploadDslContractAction < Hanami::Action
+class AllowlistedUploadDslContractAction < Hanami::Action
   contract do
     params do
       required(:id).maybe(:integer)

--- a/spec/unit/hanami/action/contract_spec.rb
+++ b/spec/unit/hanami/action/contract_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe "Contract" do
     end
 
     context "with a contract" do
-      let(:action) { WhitelistedUploadDslContractAction.new }
+      let(:action) { AllowlistedUploadDslContractAction.new }
 
       it "raw gets all params" do
         Tempfile.create("multipart-upload") do |upload|

--- a/spec/unit/hanami/action/params_spec.rb
+++ b/spec/unit/hanami/action/params_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Hanami::Action::Params do
     end
 
     context "when this feature is enabled" do
-      let(:action) { WhitelistedUploadDslAction.new }
+      let(:action) { AllowlistedUploadDslAction.new }
 
       it "raw gets all params" do
         Tempfile.create("multipart-upload") do |upload|
@@ -46,7 +46,7 @@ RSpec.describe Hanami::Action::Params do
     end
   end
 
-  describe "whitelisting" do
+  describe "allowlisting" do
     let(:params) { Class.new(Hanami::Action::Params) }
 
     context "when this feature isn't enabled" do
@@ -100,7 +100,7 @@ RSpec.describe Hanami::Action::Params do
 
     context "when this feature is enabled" do
       context "with an explicit class" do
-        let(:action) { WhitelistedParamsAction.new }
+        let(:action) { AllowlistedParamsAction.new }
 
         # For unit tests in Hanami projects, developers may want to define
         # params with symbolized keys.
@@ -158,11 +158,11 @@ RSpec.describe Hanami::Action::Params do
       end
 
       context "with an anoymous class" do
-        let(:action) { WhitelistedDslAction.new }
+        let(:action) { AllowlistedDslAction.new }
 
         it "creates a Params innerclass" do
-          expect(defined?(WhitelistedDslAction::Params)).to eq("constant")
-          expect(WhitelistedDslAction::Params.ancestors).to include(Hanami::Action::Params)
+          expect(defined?(AllowlistedDslAction::Params)).to eq("constant")
+          expect(AllowlistedDslAction::Params.ancestors).to include(Hanami::Action::Params)
         end
 
         context "in testing mode" do
@@ -380,7 +380,7 @@ RSpec.describe Hanami::Action::Params do
       expect(actual[:address][:deep]).to be_kind_of(::Hash)
     end
 
-    context "when whitelisting" do
+    context "when allowlisting" do
       # This is bug 113.
       it "handles nested params" do
         input = {
@@ -459,7 +459,7 @@ RSpec.describe Hanami::Action::Params do
       expect(actual[:address][:deep]).to be_kind_of(::Hash)
     end
 
-    context "when whitelisting" do
+    context "when allowlisting" do
       # This is bug 113.
       it "handles nested params" do
         input = {
@@ -572,7 +572,7 @@ RSpec.describe Hanami::Action::Params do
   end
 
   describe "inheritance" do
-    let(:action) { Class.new(WhitelistedParamsAction).new }
+    let(:action) { Class.new(AllowlistedParamsAction).new }
 
     it "uses the params defined in the parent class" do
       response = action.call(id: 23, unknown: 4, article: {foo: "bar", tags: [:cool]})


### PR DESCRIPTION
Related: https://thoughtbot.com/playbook/best-practices/terminology