### PR TITLE
Allow `handle_exception` to accept string class name

### DIFF
--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -433,7 +433,12 @@ module Hanami
     # @api private
     def exception_handler(exception)
       config.handled_exceptions.each do |exception_class, handler|
-        return handler if exception.is_a?(exception_class)
+        case exception_class
+        when String
+          return handler if exception.class.name == exception_class # rubocop:disable Style/ClassEqualityComparison
+        else
+          return handler if exception.is_a?(exception_class)
+        end
       end
 
       nil

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -116,6 +116,14 @@ class ErrorCallAction < Hanami::Action
   end
 end
 
+class ErrorCallWithStringClassName < Hanami::Action
+  config.handle_exception "RuntimeError" => 500
+
+  def handle(_req, _res)
+    raise
+  end
+end
+
 class MyCustomError < StandardError; end
 
 class ErrorCallFromInheritedErrorClass < Hanami::Action

--- a/spec/unit/hanami/action_spec.rb
+++ b/spec/unit/hanami/action_spec.rb
@@ -49,6 +49,13 @@ RSpec.describe Hanami::Action do
         expect(response.body).to   eq(["Internal Server Error"])
       end
 
+      it "handles string defined exception class" do
+        response = ErrorCallWithStringClassName.new.call({})
+
+        expect(response.status).to eq(500)
+        expect(response.body).to   eq(["Internal Server Error"])
+      end
+
       it "handles inherited exception with specified method" do
         response = ErrorCallFromInheritedErrorClass.new.call({})
 


### PR DESCRIPTION
This PR attempts to implement changes requested in https://github.com/hanami/hanami-controller/issues/432

Previously an error class would have to be supplied, which might mean requiring a gem in that action.

This change allows for a string to be defined instead, removing the need for requiring gems for error classes.

Fixes #432