### PR TITLE
Parse request bodies based on formats config

### DIFF
--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -310,6 +310,8 @@ module Hanami
       freeze
     end
 
+    # rubocop:disable Metrics/AbcSize
+
     # Implements the Rack/Hanami::Action protocol
     #
     # @since 0.1.0
@@ -319,8 +321,21 @@ module Hanami
       response = nil
 
       halted = catch :halt do
-        params = Params.new(env: env, contract: contract)
-        request  = build_request(
+        # Catch body parsing errors early, and wait to raise them until _after_ we've built our
+        # request and response, to give exception handlers real objects to work with.
+        body_parse_error = nil
+        begin
+          BodyParser.parse env, config
+        rescue BodyParsingError => exception
+          body_parse_error = exception
+        end
+
+        params = Params.new(
+          # Create empty params if body parsing failed, to avoid validating corrupted input.
+          env: body_parse_error ? {} : env,
+          contract: contract
+        )
+        request = build_request(
           env: env,
           params: params,
           session_enabled: session_enabled?,
@@ -334,6 +349,8 @@ module Hanami
           headers: config.default_headers,
           session_enabled: session_enabled?
         )
+
+        raise body_parse_error if body_parse_error
 
         enforce_accepted_media_types(request)
 
@@ -350,6 +367,8 @@ module Hanami
 
       finish(request, response, halted)
     end
+
+    # rubocop:enable Metrics/AbcSize
 
     protected
 

--- a/lib/hanami/action/body_parser.rb
+++ b/lib/hanami/action/body_parser.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require "rack"
+require "hanami/utils/hash"
+
+module Hanami
+  class Action
+    # Parses request bodies based on the action's accepted formats.
+    #
+    # @api private
+    module BodyParser
+      FALLBACK_KEY = :_
+
+      class << self
+        # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
+
+        # Parses the request body if applicable
+        #
+        # @param env [Hash] Rack environment
+        # @param config [Hanami::Action::Config] action configuration
+        #
+        # @return [void]
+        def parse(env, config)
+          # Body parsing requires explicit format config. Skip parsing if nothing is configured.
+          return if config.formats.empty?
+
+          # If the router has alresady parsed the body, assign it to our own parsed body keys.
+          if env.key?(ROUTER_PARSED_BODY)
+            env[ACTION_PARSED_BODY] = env[ROUTER_PARSED_BODY]
+            env[ACTION_BODY_PARAMS] = env[ROUTER_PARAMS] if env.key?(ROUTER_PARAMS)
+            return
+          end
+
+          return if env.key?(ACTION_PARSED_BODY)
+
+          input = env[::Rack::RACK_INPUT]
+          return unless input
+
+          media_type = Mime.extract_media_type(env["CONTENT_TYPE"])
+          return unless media_type
+
+          return unless Mime.accepted_content_type?(media_type, config)
+
+          parser = config.formats.body_parser_for(media_type)
+          return unless parser
+
+          input = ensure_rewindable_input(env)
+          body = read_body(input)
+          return if body.nil? || body.empty?
+
+          # Pass both the body string and the Rack env to the parser. Most parsers should only need
+          # the body, but the env is there in case access to headers or calling Rack APIs is
+          # required.
+          parsed = parser.call(body, env)
+
+          # Store the parsed body in Action-specific env keys.
+          symbolized = symbolize_body(parsed)
+          env[ACTION_PARSED_BODY] = parsed
+          env[ACTION_BODY_PARAMS] = symbolized
+
+          # Set Hanami Router keys for backward compatibility.
+          env[ROUTER_PARSED_BODY] = parsed
+          env[ROUTER_PARAMS] = symbolized
+        end
+
+        # rubocop:enable Metrics/AbcSize, Metrics/PerceivedComplexity
+
+        private
+
+        # Ensures the input in the Rack env is rewindable (for Rack 3 compatibility).
+        def ensure_rewindable_input(env)
+          input = env[::Rack::RACK_INPUT]
+          return input if input.respond_to?(:rewind)
+
+          env[::Rack::RACK_INPUT] = ::Rack::RewindableInput.new(input)
+        end
+
+        # Reads and rewinds the body.
+        def read_body(input)
+          input.rewind
+          body = input.read
+          input.rewind
+
+          body
+        end
+
+        # Symbolizes the parsed body, wrapping non-hash values in a fallback key.
+        def symbolize_body(parsed)
+          if parsed.is_a?(::Hash)
+            deep_symbolize(parsed)
+          else
+            {FALLBACK_KEY => deep_symbolize(parsed)}
+          end
+        end
+
+        # Recursively symbolizes hash keys within any structure (arrays or hashes).
+        def deep_symbolize(value)
+          case value
+          when ::Hash
+            Utils::Hash.deep_symbolize(value)
+          when ::Array
+            value.map { deep_symbolize(_1) }
+          else
+            value
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/action/body_parsers/json.rb
+++ b/lib/hanami/action/body_parsers/json.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "json"
+require_relative "../errors"
+
+module Hanami
+  class Action
+    module BodyParsers
+      # Body parser for JSON request bodies.
+      #
+      # @api private
+      module JSON
+        def self.call(body, env)
+          ::JSON.parse(body)
+        rescue ::JSON::ParserError => exception
+          raise BodyParsingError, exception.message
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/action/body_parsers/multipart_form.rb
+++ b/lib/hanami/action/body_parsers/multipart_form.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rack/multipart"
+require_relative "../errors"
+
+module Hanami
+  class Action
+    module BodyParsers
+      # Body parser for multipart form data (file uploads).
+      #
+      # @api private
+      module MultipartForm
+        def self.call(body, env)
+          # Rack's `parse_multipart` reads the input from the env. We've already rewound this input
+          # in BodyParser, before this parser is called.
+          ::Rack::Multipart.parse_multipart(env)
+        rescue StandardError => exception
+          raise BodyParsingError, exception.message
+        end
+      end
+    end
+  end
+end

--- a/lib/hanami/action/config/formats.rb
+++ b/lib/hanami/action/config/formats.rb
@@ -27,6 +27,14 @@ module Hanami
         # @api public
         attr_reader :accepted
 
+        # The registered body parsers, as a hash mapping content types to callable parsers.
+        #
+        # @return [Hash{String => #call}]
+        #
+        # @since x.x.x
+        # @api public
+        attr_reader :body_parsers
+
         # @see #accepted
         #
         # @since 2.0.0
@@ -63,6 +71,9 @@ module Hanami
           @accepted = accepted
           @default = default
           @mapping = mapping
+          @body_parsers = {}
+
+          register_default_body_parsers
         end
 
         # @since 2.0.0
@@ -72,6 +83,7 @@ module Hanami
           @accepted = original.accepted.dup
           @default = original.default
           @mapping = original.mapping.dup
+          @body_parsers = original.body_parsers.dup
         end
 
         # !@attribute [w] accepted
@@ -128,13 +140,19 @@ module Hanami
         #
         # @since 2.3.0
         # @api public
-        def register(format, media_type, accept_types: [media_type], content_types: [media_type])
+        def register(format, media_type, accept_types: [media_type], content_types: [media_type], parser: nil)
           mapping[format] = Mime::Format.new(
             name: format.to_sym,
             media_type: media_type,
             accept_types: accept_types,
             content_types: content_types
           )
+
+          if parser
+            Array(content_types).each do |ct|
+              @body_parsers[ct.downcase] = parser
+            end
+          end
 
           self
         end
@@ -285,6 +303,31 @@ module Hanami
         # @since 2.0.0
         # @api public
         alias_method :mime_types_for, :accept_types_for
+
+        # Finds the parser for a content type.
+        #
+        # @param content_type [String] the content type
+        #
+        # @return [#call, nil] the parser callable, if registered
+        #
+        # @api private
+        def body_parser_for(content_type)
+          @body_parsers[content_type&.downcase]
+        end
+
+        private
+
+        def register_default_body_parsers
+          require_relative "../body_parsers/json"
+          require_relative "../body_parsers/multipart_form"
+
+          # Multipart forms (ordinary urlencoded forms are handled by Rack automatically)
+          @body_parsers["multipart/form-data"] = BodyParsers::MultipartForm
+
+          # JSON
+          @body_parsers["application/json"] = BodyParsers::JSON
+          @body_parsers["application/vnd.api+json"] = BodyParsers::JSON
+        end
       end
     end
   end

--- a/lib/hanami/action/constants.rb
+++ b/lib/hanami/action/constants.rb
@@ -229,8 +229,32 @@ module Hanami
     # @api private
     RACK_INPUT = ::Rack::RACK_INPUT
 
-    # The key that returns router params from the Rack env
-    # This is a builtin integration for Hanami::Router
+    # The key that returns a request body parsed by Hanami Action.
+    #
+    # This is the canonical key for body parsing.
+    #
+    # @since x.x.x
+    # @api private
+    ACTION_PARSED_BODY = "hanami.action.parsed_body"
+
+    # The key that returns params from a parsed body by Hanami Action.
+    #
+    # This is the canonical key for parsed body params.
+    #
+    # @since x.x.x
+    # @api private
+    ACTION_BODY_PARAMS = "hanami.action.body_params"
+
+    # The key that returns a request body parsed by Hanami Router.
+    #
+    # This is maintained for backward compatibility with Hanami Router.
+    #
+    # @api private
+    ROUTER_PARSED_BODY = "router.parsed_body"
+
+    # The key that returns router params from the Rack env.
+    #
+    # This is maintained for backward compatibility with Hanami Router.
     #
     # @since 2.0.0
     # @api private

--- a/lib/hanami/action/errors.rb
+++ b/lib/hanami/action/errors.rb
@@ -58,6 +58,13 @@ module Hanami
       end
     end
 
+    # Error raised when body parsing fails.
+    #
+    # @api public
+    # @since x.x.x
+    class BodyParsingError < Error
+    end
+
     # Error raised when session is accessed but not enabled.
     #
     # This error is raised when `session` or `flash` is accessed/set on request/response objects

--- a/lib/hanami/action/mime.rb
+++ b/lib/hanami/action/mime.rb
@@ -195,7 +195,7 @@ module Hanami
         def format_from_media_type(media_type, config)
           return if media_type.nil?
 
-          mt = media_type.split(";").first
+          mt = extract_media_type(media_type)
           config.formats.format_for(mt) || MEDIA_TYPES_TO_FORMATS[mt]&.name
         end
 
@@ -250,6 +250,27 @@ module Hanami
           "#{content_type}; charset=#{charset}"
         end
 
+        # Extracts the media type from a Content-Type header value, removing parameters
+        # like charset, boundary, etc.
+        #
+        # @param content_type [String, nil] the Content-Type header value
+        # @return [String, nil] the media type without parameters, downcased
+        #
+        # @example
+        #   extract_media_type("application/json; charset=utf-8")
+        #   # => "application/json"
+        #
+        #   extract_media_type("multipart/form-data; boundary=----WebKitFormBoundary")
+        #   # => "multipart/form-data"
+        #
+        # @api private
+        def extract_media_type(content_type)
+          return nil if content_type.nil? || content_type.empty?
+
+          # Strip charset, boundary, and other parameters (separated by semicolon)
+          content_type.split(";", 2).first.strip.downcase
+        end
+
         # Patched version of <tt>Rack::Utils.best_q_match</tt>.
         #
         # @api private
@@ -266,6 +287,19 @@ module Hanami
 
             RequestMimeWeight.new(req_mime, quality, index, match)
           }.compact.max&.format
+        end
+
+        # Checks if a content type is acceptable for the configured formats.
+        #
+        # @param content_type [String] the media type to check
+        # @param config [Hanami::Action::Config] action configuration
+        # @return [Boolean] true if acceptable
+        #
+        # @api private
+        def accepted_content_type?(content_type, config)
+          accepted_content_types(config).any? { |accepted_content_type|
+            ::Rack::Mime.match?(content_type, accepted_content_type)
+          }
         end
 
         private
@@ -291,13 +325,6 @@ module Hanami
           FORMATS
             .fetch(format) { raise Hanami::Action::UnknownFormatError.new(format) }
             .accept_types
-        end
-
-        # @api private
-        def accepted_content_type?(content_type, config)
-          accepted_content_types(config).any? { |accepted_content_type|
-            ::Rack::Mime.match?(content_type, accepted_content_type)
-          }
         end
 
         # @api private

--- a/lib/hanami/action/params.rb
+++ b/lib/hanami/action/params.rb
@@ -348,11 +348,19 @@ module Hanami
       def _extract_params
         result = {}
 
-        if env.key?(Action::RACK_INPUT)
-          result.merge! ::Rack::Request.new(env).params
-          result.merge! _router_params
+        if env.key?(RACK_INPUT)
+          # If a body parser has already parsed the body, avoid double-parsing of the body by
+          # grabbing the query params only. Otherwise, let Rack parse both the query and body
+          # params, which covers ordinary application/x-www-form-urlencoded form posts.
+          if env.key?(ACTION_BODY_PARAMS) || env.key?(ROUTER_PARAMS)
+            result.merge! ::Rack::Request.new(env).GET
+          else
+            result.merge! ::Rack::Request.new(env).params
+          end
+
+          result.merge! _parsed_body_params
         else
-          result.merge! _router_params(env)
+          result.merge! _parsed_body_params(env)
           env[Action::REQUEST_METHOD] ||= Action::DEFAULT_REQUEST_METHOD
         end
 
@@ -361,8 +369,8 @@ module Hanami
 
       # @since 0.7.0
       # @api private
-      def _router_params(fallback = {})
-        env.fetch(ROUTER_PARAMS, fallback)
+      def _parsed_body_params(fallback = {})
+        env.fetch(ACTION_BODY_PARAMS) { env.fetch(ROUTER_PARAMS, fallback) }
       end
     end
   end

--- a/spec/integration/hanami/controller/body_parsing_spec.rb
+++ b/spec/integration/hanami/controller/body_parsing_spec.rb
@@ -1,0 +1,280 @@
+# frozen_string_literal: true
+
+require "stringio"
+
+RSpec.describe "Body parsing", :app_integration do
+  describe "JSON" do
+    it "parses JSON for actions accepting :json format" do
+      action_class = Class.new(Hanami::Action) do
+        config.formats.accept :json
+
+        def handle(req, res)
+          res.body = "City: #{req.params.dig(:user, :address, :city)}"
+        end
+      end
+
+      env = {
+        "REQUEST_METHOD" => "POST",
+        "CONTENT_TYPE" => "application/json",
+        Rack::RACK_INPUT => StringIO.new('{"user":{"address":{"city":"Rome"}}}')
+      }
+
+      status, _headers, body = action_class.new.call(env)
+
+      expect(status).to eq(200)
+      expect(body).to eq(["City: Rome"])
+    end
+  end
+
+  describe "Multipart forms" do
+    it "parses multipart forms for actions accepting :html format" do
+      action_class = Class.new(Hanami::Action) do
+        config.formats.accept :html
+
+        def handle(req, res)
+          res.body = "Title: #{req.params[:title]}"
+        end
+      end
+
+      boundary = "----WebKitFormBoundary7MA4YWxkTrZu0gW"
+      body = [
+        "------WebKitFormBoundary7MA4YWxkTrZu0gW",
+        'Content-Disposition: form-data; name="title"',
+        "",
+        "My Article",
+        "------WebKitFormBoundary7MA4YWxkTrZu0gW--"
+      ].join("\r\n")
+
+      env = {
+        "REQUEST_METHOD" => "POST",
+        "CONTENT_TYPE" => "multipart/form-data; boundary=#{boundary}",
+        "CONTENT_LENGTH" => body.bytesize.to_s,
+        Rack::RACK_INPUT => StringIO.new(body)
+      }
+
+      status, _headers, response_body = action_class.new.call(env)
+
+      expect(status).to eq(200)
+      expect(response_body).to eq(["Title: My Article"])
+    end
+
+    it "handles file uploads in multipart forms" do
+      action_class = Class.new(Hanami::Action) do
+        config.formats.accept :html
+
+        def handle(req, res)
+          upload = req.params[:upload]
+          # Rack 3 returns hash with :tempfile, Rack 2 returns file-like object
+          if upload.is_a?(Hash) && upload[:tempfile]
+            res.body = "File: #{upload[:tempfile].read}"
+          elsif upload.respond_to?(:read)
+            res.body = "File: #{upload.read}"
+          else
+            res.body = "No file"
+          end
+        end
+      end
+
+      boundary = "----WebKitFormBoundary7MA4YWxkTrZu0gW"
+      file_content = "Hello from file"
+      body = [
+        "------WebKitFormBoundary7MA4YWxkTrZu0gW",
+        'Content-Disposition: form-data; name="upload"; filename="test.txt"',
+        "Content-Type: text/plain",
+        "",
+        file_content,
+        "------WebKitFormBoundary7MA4YWxkTrZu0gW--"
+      ].join("\r\n")
+
+      env = {
+        "REQUEST_METHOD" => "POST",
+        "CONTENT_TYPE" => "multipart/form-data; boundary=#{boundary}",
+        "CONTENT_LENGTH" => body.bytesize.to_s,
+        Rack::RACK_INPUT => StringIO.new(body)
+      }
+
+      status, _headers, response_body = action_class.new.call(env)
+
+      expect(status).to eq(200)
+      expect(response_body).to eq(["File: #{file_content}"])
+    end
+  end
+
+  describe "Custom parsers" do
+    it "uses custom parser registered with format" do
+      custom_parser = lambda { |body, env|
+        # Simple "strip tags"-style parsing
+        {"data" => body.gsub(/<\/?[^>]+>/, "")}
+      }
+
+      action_class = Class.new(Hanami::Action) do
+        config.formats.register(:xml, "application/xml", parser: custom_parser)
+        config.formats.accept :xml
+
+        def handle(req, res)
+          res.body = "Data: #{req.params[:data]}"
+        end
+      end
+
+      env = {
+        "REQUEST_METHOD" => "POST",
+        "CONTENT_TYPE" => "application/xml",
+        Rack::RACK_INPUT => StringIO.new("<root>Test Content</root>")
+      }
+
+      status, _headers, body = action_class.new.call(env)
+
+      expect(status).to eq(200)
+      expect(body).to eq(["Data: Test Content"])
+    end
+  end
+
+  describe "Multiple formats" do
+    it "parses JSON when both :html and :json accepted" do
+      action_class = Class.new(Hanami::Action) do
+        config.formats.accept :html, :json
+
+        def handle(req, res)
+          res.body = "Name: #{req.params[:name]}"
+        end
+      end
+
+      env = {
+        "REQUEST_METHOD" => "POST",
+        "CONTENT_TYPE" => "application/json",
+        Rack::RACK_INPUT => StringIO.new('{"name":"Alice"}')
+      }
+
+      status, _headers, body = action_class.new.call(env)
+
+      expect(status).to eq(200)
+      expect(body).to eq(["Name: Alice"])
+    end
+
+    it "parses multipart when both :html and :json accepted" do
+      action_class = Class.new(Hanami::Action) do
+        config.formats.accept :html, :json
+
+        def handle(req, res)
+          res.body = "Title: #{req.params[:title]}"
+        end
+      end
+
+      boundary = "----WebKitFormBoundary7MA4YWxkTrZu0gW"
+      body = [
+        "------WebKitFormBoundary7MA4YWxkTrZu0gW",
+        'Content-Disposition: form-data; name="title"',
+        "",
+        "My Article",
+        "------WebKitFormBoundary7MA4YWxkTrZu0gW--"
+      ].join("\r\n")
+
+      env = {
+        "REQUEST_METHOD" => "POST",
+        "CONTENT_TYPE" => "multipart/form-data; boundary=#{boundary}",
+        "CONTENT_LENGTH" => body.bytesize.to_s,
+        Rack::RACK_INPUT => StringIO.new(body)
+      }
+
+      status, _headers, response_body = action_class.new.call(env)
+
+      expect(status).to eq(200)
+      expect(response_body).to eq(["Title: My Article"])
+    end
+  end
+
+  describe "Router parsing" do
+    it "skips parsing when router.parsed_body already present" do
+      action_class = Class.new(Hanami::Action) do
+        config.formats.accept :json
+
+        def handle(req, res)
+          res.body = "Value: #{req.params[:from_router]}"
+        end
+      end
+
+      env = {
+        "REQUEST_METHOD" => "POST",
+        "CONTENT_TYPE" => "application/json",
+        Rack::RACK_INPUT => StringIO.new('{"from_action":"should_not_appear"}'),
+        "router.parsed_body" => {"from_router" => "router_value"},
+        "router.params" => {from_router: "router_value"}
+      }
+
+      status, _headers, body = action_class.new.call(env)
+
+      expect(status).to eq(200)
+      expect(body).to eq(["Value: router_value"])
+    end
+  end
+
+  describe "Error handling" do
+    it "raises BodyParsingError for invalid JSON" do
+      action_class = Class.new(Hanami::Action) do
+        config.formats.accept :json
+
+        def handle(req, res)
+          res.body = "Should not reach here"
+        end
+      end
+
+      env = {
+        "REQUEST_METHOD" => "POST",
+        "CONTENT_TYPE" => "application/json",
+        Rack::RACK_INPUT => StringIO.new("{invalid json}")
+      }
+
+      expect {
+        action_class.new.call(env)
+      }.to raise_error(Hanami::Action::BodyParsingError)
+    end
+
+    it "raises BodyParsingError for invalid multipart data" do
+      action_class = Class.new(Hanami::Action) do
+        config.formats.accept :html
+
+        def handle(req, res)
+          res.body = "Should not reach here"
+        end
+      end
+
+      env = {
+        "REQUEST_METHOD" => "POST",
+        "CONTENT_TYPE" => "multipart/form-data; boundary=invalid",
+        "CONTENT_LENGTH" => "13",
+        Rack::RACK_INPUT => StringIO.new("invalid data!")
+      }
+
+      expect {
+        action_class.new.call(env)
+      }.to raise_error(Hanami::Action::BodyParsingError)
+    end
+
+    it "allows custom handling of body parsing errors" do
+      action_class = Class.new(Hanami::Action) do
+        config.formats.accept :json
+        config.handle_exception Hanami::Action::BodyParsingError => :handle_parse_error
+
+        def handle(req, res)
+          res.body = "Should not reach here"
+        end
+
+        def handle_parse_error(req, res, exception)
+          res.status = 400
+          res.body = "Custom error: #{exception.message}"
+        end
+      end
+
+      env = {
+        "REQUEST_METHOD" => "POST",
+        "CONTENT_TYPE" => "application/json",
+        Rack::RACK_INPUT => StringIO.new("invalid json")
+      }
+
+      status, _headers, body = action_class.new.call(env)
+
+      expect(status).to eq(400)
+      expect(body.first).to include("Custom error:")
+    end
+  end
+end

--- a/spec/unit/hanami/action/body_parser_spec.rb
+++ b/spec/unit/hanami/action/body_parser_spec.rb
@@ -1,0 +1,346 @@
+# frozen_string_literal: true
+
+require "stringio"
+
+RSpec.describe Hanami::Action::BodyParser do
+  let(:config) { Class.new(Hanami::Action).config }
+
+  describe ".parse" do
+    it "skips if body already parsed" do
+      env = {"router.parsed_body" => {existing: "data"}}
+
+      described_class.parse(env, config)
+
+      expect(env["router.parsed_body"]).to eq(existing: "data")
+      expect(env).not_to have_key("router.params")
+    end
+
+    it "skips if no rack.input" do
+      env = {}
+
+      described_class.parse(env, config)
+
+      expect(env).not_to have_key("router.parsed_body")
+    end
+
+    it "skips if no Content-Type header" do
+      env = {Rack::RACK_INPUT => StringIO.new('{"key":"value"}')}
+
+      described_class.parse(env, config)
+
+      expect(env).not_to have_key("router.parsed_body")
+    end
+
+    it "skips if Content-Type is empty" do
+      env = {
+        "CONTENT_TYPE" => "",
+        Rack::RACK_INPUT => StringIO.new('{"key":"value"}')
+      }
+
+      described_class.parse(env, config)
+
+      expect(env).not_to have_key("router.parsed_body")
+    end
+
+    it "skips if no formats configured" do
+      env = {
+        "CONTENT_TYPE" => "application/json",
+        Rack::RACK_INPUT => StringIO.new('{"key":"value"}')
+      }
+
+      described_class.parse(env, config)
+
+      expect(env).not_to have_key("router.parsed_body")
+    end
+
+    it "skips if content type not acceptable for configured formats" do
+      config.formats.accept :html
+
+      env = {
+        "CONTENT_TYPE" => "application/json",
+        Rack::RACK_INPUT => StringIO.new('{"key":"value"}')
+      }
+
+      described_class.parse(env, config)
+
+      expect(env).not_to have_key("router.parsed_body")
+    end
+
+    it "skips if no parser registered for content type" do
+      config.formats.register(:custom, "application/custom")
+      config.formats.accept :custom
+
+      env = {
+        "CONTENT_TYPE" => "application/custom",
+        Rack::RACK_INPUT => StringIO.new("some data")
+      }
+
+      described_class.parse(env, config)
+
+      expect(env).not_to have_key("router.parsed_body")
+    end
+
+    it "skips if body is empty" do
+      config.formats.accept :json
+
+      env = {
+        "CONTENT_TYPE" => "application/json",
+        Rack::RACK_INPUT => StringIO.new("")
+      }
+
+      described_class.parse(env, config)
+
+      expect(env).not_to have_key("router.parsed_body")
+    end
+
+    context "with JSON request" do
+      it "parses when format accepted" do
+        config.formats.accept :json
+
+        env = {
+          "CONTENT_TYPE" => "application/json",
+          Rack::RACK_INPUT => StringIO.new('{"name":"Alice","age":30}')
+        }
+
+        described_class.parse(env, config)
+
+        expect(env["router.parsed_body"]).to eq("name" => "Alice", "age" => 30)
+        expect(env["router.params"]).to eq(name: "Alice", age: 30)
+      end
+
+      it "parses application/vnd.api+json" do
+        # Register JSON:API format with vnd.api+json content type
+        config.formats.register(:jsonapi, "application/vnd.api+json",
+                                content_types: ["application/vnd.api+json"])
+        config.formats.accept :jsonapi
+
+        env = {
+          "CONTENT_TYPE" => "application/vnd.api+json",
+          Rack::RACK_INPUT => StringIO.new('{"data":{"type":"articles"}}')
+        }
+
+        described_class.parse(env, config)
+
+        expect(env["router.parsed_body"]).to eq("data" => {"type" => "articles"})
+        expect(env["router.params"]).to eq(data: {type: "articles"})
+      end
+
+      it "strips charset from Content-Type" do
+        config.formats.accept :json
+
+        env = {
+          "CONTENT_TYPE" => "application/json; charset=utf-8",
+          Rack::RACK_INPUT => StringIO.new('{"key":"value"}')
+        }
+
+        described_class.parse(env, config)
+
+        expect(env["router.parsed_body"]).to eq("key" => "value")
+      end
+
+      it "handles nested objects" do
+        config.formats.accept :json
+
+        env = {
+          "CONTENT_TYPE" => "application/json",
+          Rack::RACK_INPUT => StringIO.new('{"user":{"name":"Alice","tags":["ruby","hanami"]}}')
+        }
+
+        described_class.parse(env, config)
+
+        expect(env["router.params"]).to eq(
+          user: {
+            name: "Alice",
+            tags: ["ruby", "hanami"]
+          }
+        )
+      end
+
+      it "handles non-hash JSON (arrays)" do
+        config.formats.accept :json
+
+        env = {
+          "CONTENT_TYPE" => "application/json",
+          Rack::RACK_INPUT => StringIO.new("[1,2,3]")
+        }
+
+        described_class.parse(env, config)
+
+        expect(env["router.parsed_body"]).to eq([1, 2, 3])
+        expect(env["router.params"]).to eq(_: [1, 2, 3])
+      end
+
+      it "handles non-hash JSON with nested hashes (arrays of objects)" do
+        config.formats.accept :json
+
+        env = {
+          "CONTENT_TYPE" => "application/json",
+          Rack::RACK_INPUT => StringIO.new('[{"name":"Alice","age":30},{"name":"Bob","age":25}]')
+        }
+
+        described_class.parse(env, config)
+
+        expect(env["router.parsed_body"]).to eq([{"name" => "Alice", "age" => 30}, {"name" => "Bob", "age" => 25}])
+        expect(env["router.params"]).to eq(_: [{name: "Alice", age: 30}, {name: "Bob", age: 25}])
+      end
+    end
+
+    context "with multipart form request" do
+      it "parses when format accepted" do
+        config.formats.accept :html
+
+        boundary = "----WebKitFormBoundary7MA4YWxkTrZu0gW"
+        body = [
+          "------WebKitFormBoundary7MA4YWxkTrZu0gW",
+          'Content-Disposition: form-data; name="title"',
+          "",
+          "My Title",
+          "------WebKitFormBoundary7MA4YWxkTrZu0gW--"
+        ].join("\r\n")
+
+        env = {
+          "CONTENT_TYPE" => "multipart/form-data; boundary=#{boundary}",
+          "CONTENT_LENGTH" => body.bytesize.to_s,
+          Rack::RACK_INPUT => StringIO.new(body)
+        }
+
+        described_class.parse(env, config)
+
+        expect(env["router.parsed_body"]).to eq("title" => "My Title")
+        expect(env["router.params"]).to eq(title: "My Title")
+      end
+
+      it "does not parse when only JSON accepted" do
+        config.formats.accept :json
+
+        boundary = "----WebKitFormBoundary7MA4YWxkTrZu0gW"
+        body = [
+          "------WebKitFormBoundary7MA4YWxkTrZu0gW",
+          'Content-Disposition: form-data; name="title"',
+          "",
+          "My Title",
+          "------WebKitFormBoundary7MA4YWxkTrZu0gW--"
+        ].join("\r\n")
+
+        env = {
+          "CONTENT_TYPE" => "multipart/form-data; boundary=#{boundary}",
+          "CONTENT_LENGTH" => body.bytesize.to_s,
+          Rack::RACK_INPUT => StringIO.new(body)
+        }
+
+        described_class.parse(env, config)
+
+        expect(env).not_to have_key("router.parsed_body")
+      end
+    end
+
+    context "with custom parser" do
+      it "uses custom parser when registered" do
+        custom_parser = ->(body, env) { {"custom" => "parsed: #{body}"} }
+
+        config.formats.register(:custom, "application/custom", parser: custom_parser)
+        config.formats.accept :custom
+
+        env = {
+          "CONTENT_TYPE" => "application/custom",
+          Rack::RACK_INPUT => StringIO.new("test data")
+        }
+
+        described_class.parse(env, config)
+
+        expect(env["router.parsed_body"]).to eq("custom" => "parsed: test data")
+        expect(env["router.params"]).to eq(custom: "parsed: test data")
+      end
+
+      it "uses directly registered parser" do
+        custom_parser = ->(body, env) { {"direct" => body.upcase} }
+        config.formats.body_parsers["application/direct"] = custom_parser
+        config.formats.register(:direct, "application/direct")
+        config.formats.accept :direct
+
+        env = {
+          "CONTENT_TYPE" => "application/direct",
+          Rack::RACK_INPUT => StringIO.new("hello")
+        }
+
+        described_class.parse(env, config)
+
+        expect(env["router.parsed_body"]).to eq("direct" => "HELLO")
+      end
+    end
+
+    context "with multiple formats accepted" do
+      it "parses JSON when JSON format accepted along with HTML" do
+        config.formats.accept :html, :json
+
+        env = {
+          "CONTENT_TYPE" => "application/json",
+          Rack::RACK_INPUT => StringIO.new('{"key":"value"}')
+        }
+
+        described_class.parse(env, config)
+
+        expect(env["router.parsed_body"]).to eq("key" => "value")
+      end
+
+      it "parses multipart when HTML format accepted along with JSON" do
+        config.formats.accept :json, :html
+
+        boundary = "----WebKitFormBoundary7MA4YWxkTrZu0gW"
+        body = [
+          "------WebKitFormBoundary7MA4YWxkTrZu0gW",
+          'Content-Disposition: form-data; name="field"',
+          "",
+          "value",
+          "------WebKitFormBoundary7MA4YWxkTrZu0gW--"
+        ].join("\r\n")
+
+        env = {
+          "CONTENT_TYPE" => "multipart/form-data; boundary=#{boundary}",
+          "CONTENT_LENGTH" => body.bytesize.to_s,
+          Rack::RACK_INPUT => StringIO.new(body)
+        }
+
+        described_class.parse(env, config)
+
+        expect(env["router.parsed_body"]).to eq("field" => "value")
+      end
+    end
+
+    context "input rewinding" do
+      it "rewinds input before and after reading" do
+        config.formats.accept :json
+
+        input = StringIO.new('{"key":"value"}')
+        env = {
+          "CONTENT_TYPE" => "application/json",
+          Rack::RACK_INPUT => input
+        }
+
+        described_class.parse(env, config)
+
+        expect(env["router.parsed_body"]).to eq("key" => "value")
+        expect(input.pos).to eq(0) # Should be rewound
+      end
+
+      it "makes non-rewindable input rewindable" do
+        config.formats.accept :json
+
+        # Create a non-rewindable input
+        input = StringIO.new('{"key":"value"}')
+        input.singleton_class.undef_method(:rewind)
+
+        env = {
+          "CONTENT_TYPE" => "application/json",
+          Rack::RACK_INPUT => input
+        }
+
+        expect {
+          described_class.parse(env, config)
+        }.not_to raise_error
+
+        expect(env["router.parsed_body"]).to eq("key" => "value")
+      end
+    end
+  end
+end

--- a/spec/unit/hanami/action/body_parsers/json_spec.rb
+++ b/spec/unit/hanami/action/body_parsers/json_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.describe Hanami::Action::BodyParsers::JSON, ".call" do
+  it "parses valid JSON" do
+    body = '{"user":{"name":"Alice","address":{"city":"Rome"}}}'
+    result = described_class.call(body, {})
+
+    expect(result).to eq(
+      "user" => {
+        "name" => "Alice",
+        "address" => {"city" => "Rome"}
+      }
+    )
+  end
+
+  it "parses JSON arrays" do
+    body = '[{"id":1},{"id":2}]'
+    result = described_class.call(body, {})
+
+    expect(result).to eq([{"id" => 1}, {"id" => 2}])
+  end
+
+  it "parses empty JSON object" do
+    body = "{}"
+    result = described_class.call(body, {})
+
+    expect(result).to eq({})
+  end
+
+  it "raises BodyParsingError on invalid JSON" do
+    body = "{invalid json}"
+
+    expect {
+      described_class.call(body, {})
+    }.to raise_error(Hanami::Action::BodyParsingError)
+  end
+end

--- a/spec/unit/hanami/action/body_parsers/multipart_form_spec.rb
+++ b/spec/unit/hanami/action/body_parsers/multipart_form_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "stringio"
+
+RSpec.describe Hanami::Action::BodyParsers::MultipartForm, ".call" do
+  it "parses multipart form data" do
+    boundary = "----WebKitFormBoundary7MA4YWxkTrZu0gW"
+    body = [
+      "------WebKitFormBoundary7MA4YWxkTrZu0gW",
+      'Content-Disposition: form-data; name="title"',
+      "",
+      "My Title",
+      "------WebKitFormBoundary7MA4YWxkTrZu0gW",
+      'Content-Disposition: form-data; name="body"',
+      "",
+      "My Body",
+      "------WebKitFormBoundary7MA4YWxkTrZu0gW--"
+    ].join("\r\n")
+
+    env = {
+      "CONTENT_TYPE" => "multipart/form-data; boundary=#{boundary}",
+      "CONTENT_LENGTH" => body.bytesize.to_s,
+      Rack::RACK_INPUT => StringIO.new(body)
+    }
+
+    result = described_class.call(body, env)
+
+    expect(result).to eq("title" => "My Title", "body" => "My Body")
+  end
+
+  it "parses file uploads" do
+    boundary = "----WebKitFormBoundary7MA4YWxkTrZu0gW"
+    file_content = "file content here"
+    body = [
+      "------WebKitFormBoundary7MA4YWxkTrZu0gW",
+      'Content-Disposition: form-data; name="upload"; filename="test.txt"',
+      "Content-Type: text/plain",
+      "",
+      file_content,
+      "------WebKitFormBoundary7MA4YWxkTrZu0gW--"
+    ].join("\r\n")
+
+    env = {
+      "CONTENT_TYPE" => "multipart/form-data; boundary=#{boundary}",
+      "CONTENT_LENGTH" => body.bytesize.to_s,
+      Rack::RACK_INPUT => StringIO.new(body)
+    }
+
+    result = described_class.call(body, env)
+
+    expect(result).to have_key("upload")
+    upload = result["upload"]
+
+    # Rack 3 returns a hash with :tempfile key
+    if upload.is_a?(Hash)
+      expect(upload[:tempfile]).to respond_to(:read)
+      expect(upload[:tempfile].read).to eq(file_content)
+    else
+      # Rack 2 compatibility
+      expect(upload).to respond_to(:read)
+      expect(upload.read).to eq(file_content)
+    end
+  end
+
+  it "raises BodyParsingError on invalid multipart data" do
+    body = "not valid multipart data"
+
+    env = {
+      "CONTENT_TYPE" => "multipart/form-data; boundary=invalid",
+      "CONTENT_LENGTH" => body.bytesize.to_s,
+      Rack::RACK_INPUT => StringIO.new(body)
+    }
+
+    expect {
+      described_class.call(body, env)
+    }.to raise_error(Hanami::Action::BodyParsingError)
+  end
+end

--- a/spec/unit/hanami/action/config/formats_spec.rb
+++ b/spec/unit/hanami/action/config/formats_spec.rb
@@ -28,6 +28,37 @@ RSpec.describe Hanami::Action::Config::Formats do
           )
         )
     end
+
+    it "registers parser for content types" do
+      parser = ->(body, env) { {"parsed" => true} }
+
+      formats.register(:custom, "application/custom", parser: parser)
+
+      expect(formats.body_parser_for("application/custom")).to eq(parser)
+    end
+
+    it "registers parser for multiple content types" do
+      parser = ->(body, env) { {"parsed" => true} }
+
+      formats.register(
+        :custom,
+        "application/custom",
+        content_types: ["application/custom", "application/x-custom"],
+        parser: parser
+      )
+
+      expect(formats.body_parser_for("application/custom")).to eq(parser)
+      expect(formats.body_parser_for("application/x-custom")).to eq(parser)
+    end
+
+    it "normalizes content type case when registering parser" do
+      parser = ->(body, env) { {"parsed" => true} }
+
+      formats.register(:custom, "Application/Custom", parser: parser)
+
+      expect(formats.body_parser_for("application/custom")).to eq(parser)
+      expect(formats.body_parser_for("APPLICATION/CUSTOM")).to eq(parser)
+    end
   end
 
   describe "#accepted" do
@@ -45,6 +76,50 @@ RSpec.describe Hanami::Action::Config::Formats do
       expect { formats.accepted = [:json, :html] }
         .to change { formats.accepted }
         .to [:json, :html]
+    end
+  end
+
+  describe "#body_parsers" do
+    it "is exposed as an attribute" do
+      expect(formats.body_parsers).to be_a(Hash)
+    end
+
+    it "allows direct parser registration" do
+      parser = ->(body, env) { {"direct" => true} }
+      formats.body_parsers["application/direct"] = parser
+
+      expect(formats.body_parser_for("application/direct")).to eq(parser)
+    end
+
+    it "includes default parsers for JSON" do
+      expect(formats.body_parser_for("application/json")).to eq(Hanami::Action::BodyParsers::JSON)
+      expect(formats.body_parser_for("application/vnd.api+json")).to eq(Hanami::Action::BodyParsers::JSON)
+    end
+
+    it "includes default parser for multipart forms" do
+      expect(formats.body_parser_for("multipart/form-data")).to eq(Hanami::Action::BodyParsers::MultipartForm)
+    end
+  end
+
+  describe "#body_parser_for" do
+    it "returns parser for registered content type" do
+      parser = formats.body_parser_for("application/json")
+
+      expect(parser).to eq(Hanami::Action::BodyParsers::JSON)
+    end
+
+    it "returns nil for unregistered content type" do
+      expect(formats.body_parser_for("application/unknown")).to be_nil
+    end
+
+    it "is case-insensitive" do
+      parser = formats.body_parser_for("APPLICATION/JSON")
+
+      expect(parser).to eq(Hanami::Action::BodyParsers::JSON)
+    end
+
+    it "handles nil content type" do
+      expect(formats.body_parser_for(nil)).to be_nil
     end
   end
 


### PR DESCRIPTION
Introduce body parsing to Hanami Action, which runs according to the action's configured format. Now Hanami Action can be used completely standalone and provide all the functionality you would expect when it comes to parsing and handling params.

By default, it includes default body parsers for JSON and multipart form requests.

The overall approach to body parsing is the same as Hanami Router, which this new feature will supersede for full Hanami apps:

- All keys in parsed bodies are deeply symbolized.
- Non-hash parsed bodies (e.g. JSON arrays) are wrapped in `{_: parsed_body}`.
- Parsed body data is merged into `request.params`.

Because parsing is now handled at the action level, this means a more "correct" overall behaviour, however, because body parsing will only occur if the request matches on of the action's accepted formats.

Failed body parsing will raise a new `Hanami::Action::BodyParsingError`, which users can handle in their own action classes if they wish to provide a custom response to failed parsing.

This also includes compatibility with router-handled parsing: if `env["router.parsed_body"]` is already set, body parsing will be skipped, and the `"router.parsed_body"` and `"router.params"` keys are used.

### Other details

- Parsers can be registered when registering formats, as a convenience: `formats.register(:custom, "application/custom", parser: ->(body, env) { ... })`
- Parsers can also be registered independently: `formats.body_parsers["application/custom"] = parser`
- Even though most parsers would only care about the `body` being given, we also pass `env` in case future parsers need to access headers or other Rack APIs that require then env (which we actually do inside the multipart form parser).
- The body parsing logic is encapsulated in a single module: `Hanami::Action::BodyParser`. This is mostly about mutating the rack env, but because body parsing is such a distinct concern, keeping this separate allows the code to be understood most easily (i.e. we don't make `action.rb` so big)
- Just like we did in Hanami Router as part of our Rack 3 transition, we take care to make the input rewindable, and then rewind it after we've done the work of reading and parsing the body.
- Since the body parsing logic uses a lot of media type checking (we only attempt to parse if the action accepts the corresponding format), I made a few more of the methods on `Mime` public, so they could be re-used here.
- In `Action#call`, since body parsing occurs early, its error is caught and then "suspended" until the `request` and `response` objects are built, and at that point re-raised, which ensures custom exception handlers can have access to the `request` and `response` objects they expect.

Overall, this feels like a really solid improvement, but there's one gotcha: multipart form bodies won't be parsed unless you add `formats.accept :html`. Same deal for JSON bodies and `formats.accept :json`. This is because we connect body parsing with format acceptance. This is IMO the most "correct" behaviour, but it will mean that we will probably need to encourage Hanami app authors to specify a default format to accept across their actions. For Hanami 2.3, our stopgap measure we just to parse multipart forms and JSON bodies _at all times_ (if such bodies were provided). This required zero boilerplate, but it is possibly "overstepping" a little, adding behaviour where you didn't expect it.

Fixes #484