### PR TITLE
Fix url params getting removed

### DIFF
--- a/lib/hanami/action/body_parser.rb
+++ b/lib/hanami/action/body_parser.rb
@@ -64,7 +64,7 @@ module Hanami
 
           # Set Hanami Router keys for backward compatibility.
           env[ROUTER_PARSED_BODY] = parsed
-          env[ROUTER_PARAMS] = symbolized
+          env[ROUTER_PARAMS] = env.fetch(ROUTER_PARAMS, {}).merge(symbolized)
         end
 
         # rubocop:enable Metrics/AbcSize, Metrics/PerceivedComplexity

--- a/lib/hanami/action/params.rb
+++ b/lib/hanami/action/params.rb
@@ -370,7 +370,7 @@ module Hanami
       # @since 0.7.0
       # @api private
       def _parsed_body_params(fallback = {})
-        env.fetch(ACTION_BODY_PARAMS) { env.fetch(ROUTER_PARAMS, fallback) }
+        env.fetch(ROUTER_PARAMS) { env.fetch(ACTION_BODY_PARAMS, fallback) }
       end
     end
   end

--- a/spec/integration/body_parser_route_params_spec.rb
+++ b/spec/integration/body_parser_route_params_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+RSpec.describe "Body parser route params integration" do
+  let(:action) do
+    Class.new(Hanami::Action) do
+      config.formats.accept :html, :json
+
+      params do
+        required(:id).filled(:str?)
+
+        required(:painter).schema do
+          required(:first_name).filled(:str?)
+          required(:last_name).filled(:str?)
+        end
+      end
+
+      def handle(req, res)
+        res.body = req.params.to_h.inspect
+      end
+    end.new
+  end
+
+  let(:app) do
+    current_action = action
+
+    routes = Hanami::Router.new do
+      patch "/painters/:id", to: current_action
+    end
+
+    Rack::MockRequest.new(
+      Rack::Builder.new do
+        use Rack::Lint
+        run routes
+      end.to_app
+    )
+  end
+
+  it "preserves route params when parsing JSON" do
+    response = app.request(
+      "PATCH",
+      "/painters/23",
+      "CONTENT_TYPE" => "application/json",
+      input: {painter: {first_name: "Gustav", last_name: "Klimt"}}.to_json
+    )
+
+    expect(response.status).to eq(200)
+    expect(response.body).to eq({id: "23", painter: {first_name: "Gustav", last_name: "Klimt"}}.inspect)
+  end
+
+  it "preserves route params when parsing multipart form data" do
+    boundary = "----WebKitFormBoundary7MA4YWxkTrZu0gW"
+    body = [
+      "--#{boundary}",
+      'Content-Disposition: form-data; name="painter[first_name]"',
+      "",
+      "Gustav",
+      "--#{boundary}",
+      'Content-Disposition: form-data; name="painter[last_name]"',
+      "",
+      "Klimt",
+      "--#{boundary}--"
+    ].join("\r\n")
+
+    response = app.request(
+      "PATCH",
+      "/painters/23",
+      "CONTENT_TYPE" => "multipart/form-data; boundary=#{boundary}",
+      "CONTENT_LENGTH" => body.bytesize.to_s,
+      input: body
+    )
+
+    expect(response.status).to eq(200)
+    expect(response.body).to eq({id: "23", painter: {first_name: "Gustav", last_name: "Klimt"}}.inspect)
+  end
+end

--- a/spec/unit/hanami/action/body_parser_spec.rb
+++ b/spec/unit/hanami/action/body_parser_spec.rb
@@ -153,6 +153,21 @@ RSpec.describe Hanami::Action::BodyParser do
         expect(env["router.params"]).to eq(name: "Alice", age: 30)
       end
 
+      it "preserves existing route params when parsing JSON" do
+        config.formats.accept :json
+
+        env = {
+          "CONTENT_TYPE" => "application/json",
+          Rack::RACK_INPUT => StringIO.new('{"comment":{"body":"hello"}}'),
+          "router.params" => {slug: "my-article"}
+        }
+
+        described_class.parse(env, config)
+
+        expect(env["router.parsed_body"]).to eq("comment" => {"body" => "hello"})
+        expect(env["router.params"]).to eq(slug: "my-article", comment: {body: "hello"})
+      end
+
       it "parses application/vnd.api+json" do
         # Register JSON:API format with vnd.api+json content type
         config.formats.register(:jsonapi, "application/vnd.api+json",
@@ -253,6 +268,31 @@ RSpec.describe Hanami::Action::BodyParser do
 
         expect(env["router.parsed_body"]).to eq("title" => "My Title")
         expect(env["router.params"]).to eq(title: "My Title")
+      end
+
+      it "preserves existing route params when parsing multipart data" do
+        config.formats.accept :html
+
+        boundary = "----WebKitFormBoundary7MA4YWxkTrZu0gW"
+        body = [
+          "------WebKitFormBoundary7MA4YWxkTrZu0gW",
+          'Content-Disposition: form-data; name="title"',
+          "",
+          "My Title",
+          "------WebKitFormBoundary7MA4YWxkTrZu0gW--"
+        ].join("\r\n")
+
+        env = {
+          "CONTENT_TYPE" => "multipart/form-data; boundary=#{boundary}",
+          "CONTENT_LENGTH" => body.bytesize.to_s,
+          Rack::RACK_INPUT => StringIO.new(body),
+          "router.params" => {slug: "my-article"}
+        }
+
+        described_class.parse(env, config)
+
+        expect(env["router.parsed_body"]).to eq("title" => "My Title")
+        expect(env["router.params"]).to eq(slug: "my-article", title: "My Title")
       end
 
       it "does not parse when only JSON accepted" do

--- a/spec/unit/hanami/action/params_spec.rb
+++ b/spec/unit/hanami/action/params_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rack"
+require "json"
 
 RSpec.describe Hanami::Action::Params do
   describe "#raw" do
@@ -561,6 +562,78 @@ RSpec.describe Hanami::Action::Params do
           ArgumentError,
           %(Can't add :book, :code, "is invalid" to {book: ["is missing"]})
         )
+      end
+    end
+  end
+
+  describe "JSON body with route params" do
+    subject(:action) do
+      Class.new(Hanami::Action) do
+        config.formats.accept :json
+
+        def handle(req, res)
+          res.body = req.params.to_h.inspect
+        end
+      end.new
+    end
+
+    # Simulates the action parsing the JSON body itself (standalone use, no router body parsing).
+    def action_parsed_env(route_params:, body:)
+      Rack::MockRequest.env_for(
+        "/",
+        method: "POST",
+        input: JSON.generate(body),
+        "CONTENT_TYPE" => "application/json",
+        "router.params" => route_params,
+      )
+    end
+
+    # Simulates what hanami-router does: parse the JSON body and merge everything
+    # into router.params before handing off to the action.
+    def router_parsed_env(route_params:, body:)
+      raw_json = JSON.generate(body)
+      parsed = JSON.parse(raw_json)
+      symbolized = JSON.parse(raw_json, symbolize_names: true)
+
+      Rack::MockRequest.env_for(
+        "/",
+        method: "POST",
+        input: raw_json,
+        "CONTENT_TYPE" => "application/json",
+        "router.params" => route_params.merge(symbolized),
+        "router.parsed_body" => parsed,
+      )
+    end
+
+    context "when the action parses the JSON body (standalone, no router body parsing)" do
+      it "includes route params alongside JSON body params" do
+        env = action_parsed_env(route_params: {slug: "my-article"}, body: {comment: {body: "hello"}})
+        response = action.call(env)
+
+        expect(response[:params][:slug]).to eq("my-article")
+        expect(response[:params][:comment]).to eq({body: "hello"})
+      end
+
+      it "includes route params when there is no body" do
+        env = Rack::MockRequest.env_for(
+          "/",
+          method: "POST",
+          "CONTENT_TYPE" => "application/json",
+          "router.params" => {slug: "my-article"},
+        )
+        response = action.call(env)
+
+        expect(response[:params][:slug]).to eq("my-article")
+      end
+    end
+
+    context "when the router pre-parses the JSON body" do
+      it "includes route params alongside JSON body params" do
+        env = router_parsed_env(route_params: {slug: "my-article"}, body: {comment: {body: "hello"}})
+        response = action.call(env)
+
+        expect(response[:params][:slug]).to eq("my-article")
+        expect(response[:params][:comment]).to eq({body: "hello"})
       end
     end
   end

--- a/spec/unit/hanami/action/params_spec.rb
+++ b/spec/unit/hanami/action/params_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "rack"
-require "json"
 
 RSpec.describe Hanami::Action::Params do
   describe "#raw" do
@@ -562,78 +561,6 @@ RSpec.describe Hanami::Action::Params do
           ArgumentError,
           %(Can't add :book, :code, "is invalid" to {book: ["is missing"]})
         )
-      end
-    end
-  end
-
-  describe "JSON body with route params" do
-    subject(:action) do
-      Class.new(Hanami::Action) do
-        config.formats.accept :json
-
-        def handle(req, res)
-          res.body = req.params.to_h.inspect
-        end
-      end.new
-    end
-
-    # Simulates the action parsing the JSON body itself (standalone use, no router body parsing).
-    def action_parsed_env(route_params:, body:)
-      Rack::MockRequest.env_for(
-        "/",
-        method: "POST",
-        input: JSON.generate(body),
-        "CONTENT_TYPE" => "application/json",
-        "router.params" => route_params,
-      )
-    end
-
-    # Simulates what hanami-router does: parse the JSON body and merge everything
-    # into router.params before handing off to the action.
-    def router_parsed_env(route_params:, body:)
-      raw_json = JSON.generate(body)
-      parsed = JSON.parse(raw_json)
-      symbolized = JSON.parse(raw_json, symbolize_names: true)
-
-      Rack::MockRequest.env_for(
-        "/",
-        method: "POST",
-        input: raw_json,
-        "CONTENT_TYPE" => "application/json",
-        "router.params" => route_params.merge(symbolized),
-        "router.parsed_body" => parsed,
-      )
-    end
-
-    context "when the action parses the JSON body (standalone, no router body parsing)" do
-      it "includes route params alongside JSON body params" do
-        env = action_parsed_env(route_params: {slug: "my-article"}, body: {comment: {body: "hello"}})
-        response = action.call(env)
-
-        expect(response[:params][:slug]).to eq("my-article")
-        expect(response[:params][:comment]).to eq({body: "hello"})
-      end
-
-      it "includes route params when there is no body" do
-        env = Rack::MockRequest.env_for(
-          "/",
-          method: "POST",
-          "CONTENT_TYPE" => "application/json",
-          "router.params" => {slug: "my-article"},
-        )
-        response = action.call(env)
-
-        expect(response[:params][:slug]).to eq("my-article")
-      end
-    end
-
-    context "when the router pre-parses the JSON body" do
-      it "includes route params alongside JSON body params" do
-        env = router_parsed_env(route_params: {slug: "my-article"}, body: {comment: {body: "hello"}})
-        response = action.call(env)
-
-        expect(response[:params][:slug]).to eq("my-article")
-        expect(response[:params][:comment]).to eq({body: "hello"})
       end
     end
   end


### PR DESCRIPTION
Fixes a bug I found introduced in #500: when a JSON body was being parsed, params from the url were being stripped.

The spec I wrote fails for 'main', but passes for v2.3.1 and after this change, confirming this was a regression.

I also added an analogous regression test for multipart form submissions