### PR TITLE
Clean up params extraction; fix bodyless env leak

### DIFF
--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -320,6 +320,11 @@ module Hanami
           env: body_parse_error ? {} : env,
           contract: contract
         )
+
+        # Ensure env has REQUEST_METHOD for downstream code (e.g. Response) when actions are called
+        # with a direct params hash as a testing convenience.
+        env[REQUEST_METHOD] ||= DEFAULT_REQUEST_METHOD
+
         request = build_request(
           env: env,
           params: params,

--- a/lib/hanami/action/body_parser.rb
+++ b/lib/hanami/action/body_parser.rb
@@ -21,10 +21,11 @@ module Hanami
         #
         # @return [void]
         def parse(env, config)
-          # If the router has already parsed the body, assign it to our own parsed body keys.
+          # If the router has already parsed the body, derive our own keys from it.
           if env.key?(ROUTER_PARSED_BODY)
-            env[ACTION_PARSED_BODY] = env[ROUTER_PARSED_BODY]
-            env[ACTION_BODY_PARAMS] = env[ROUTER_PARAMS] if env.key?(ROUTER_PARAMS)
+            parsed = env[ROUTER_PARSED_BODY]
+            env[ACTION_PARSED_BODY] = parsed
+            env[ACTION_BODY_PARAMS] = symbolize_body(parsed)
             return
           end
 
@@ -57,14 +58,8 @@ module Hanami
           # required.
           parsed = parser.call(body, env)
 
-          # Store the parsed body in Action-specific env keys.
-          symbolized = symbolize_body(parsed)
           env[ACTION_PARSED_BODY] = parsed
-          env[ACTION_BODY_PARAMS] = symbolized
-
-          # Set Hanami Router keys for backward compatibility.
-          env[ROUTER_PARSED_BODY] = parsed
-          env[ROUTER_PARAMS] = env.fetch(ROUTER_PARAMS, {}).merge(symbolized)
+          env[ACTION_BODY_PARAMS] = symbolize_body(parsed)
         end
 
         # rubocop:enable Metrics/AbcSize, Metrics/PerceivedComplexity

--- a/lib/hanami/action/params.rb
+++ b/lib/hanami/action/params.rb
@@ -345,12 +345,11 @@ module Hanami
 
       # @since 0.7.0
       # @api private
-      def _extract_params # rubocop:disable Metrics/AbcSize
+      def _extract_params
         result = {}
 
         unless env.key?(RACK_INPUT)
           result.merge! _parsed_body_params(env)
-          env[Action::REQUEST_METHOD] ||= Action::DEFAULT_REQUEST_METHOD
           return result
         end
 

--- a/lib/hanami/action/params.rb
+++ b/lib/hanami/action/params.rb
@@ -16,14 +16,11 @@ module Hanami
     #
     # @see Hanami::Action::Request#params
 
-    # A set of params requested by the client
+    # A set of params requested by the client.
     #
-    # It's able to extract the relevant params from a Rack env of from an Hash.
-    #
-    # There are three scenarios:
-    #   * When used with Hanami::Router: it contains only the params from the request
-    #   * When used standalone: it contains all the Rack env
-    #   * Default: it returns the given hash as it is. It's useful for testing purposes.
+    # Extracts the relevant params from a Rack env (query string, request body, and route params
+    # placed in `env["router.params"]` by the router), or from a plain hash passed for convenience
+    # in tests.
     #
     # @since 0.1.0
     class Params
@@ -343,16 +340,13 @@ module Hanami
 
       private
 
-      # @since 0.7.0
-      # @api private
       def _extract_params # rubocop:disable Metrics/AbcSize
+        # Without PATH_INFO (URL path from a server) or rack.input (request body), env has no
+        # Rack-sourced data for us to parse as params; it's likely a bare hash passed to
+        # `Action#call` for convenience in tests. In this case, treat the env itself as the params.
+        return env unless env.key?("PATH_INFO") || env.key?(RACK_INPUT)
+
         result = {}
-
-        unless env.key?("PATH_INFO") || env.key?(RACK_INPUT)
-          result.merge! _parsed_body_params(env)
-          return result
-        end
-
         rack_request = ::Rack::Request.new(env)
 
         # Start with the query string params.
@@ -366,12 +360,6 @@ module Hanami
         result.merge!(env[ACTION_BODY_PARAMS]) if env.key?(ACTION_BODY_PARAMS)
 
         result
-      end
-
-      # @since 0.7.0
-      # @api private
-      def _parsed_body_params(fallback = {})
-        env.fetch(ROUTER_PARAMS) { env.fetch(ACTION_BODY_PARAMS, fallback) }
       end
     end
   end

--- a/lib/hanami/action/params.rb
+++ b/lib/hanami/action/params.rb
@@ -345,10 +345,10 @@ module Hanami
 
       # @since 0.7.0
       # @api private
-      def _extract_params
+      def _extract_params # rubocop:disable Metrics/AbcSize
         result = {}
 
-        unless env.key?(RACK_INPUT)
+        unless env.key?("PATH_INFO") || env.key?(RACK_INPUT)
           result.merge! _parsed_body_params(env)
           return result
         end
@@ -358,8 +358,8 @@ module Hanami
         # Start with the query string params.
         result.merge!(rack_request.GET)
 
-        # Merge form-urlencoded body params if BodyParser hasn't already consumed the body.
-        result.merge!(rack_request.POST) unless env.key?(ACTION_BODY_PARAMS)
+        # Merge form-urlencoded body params if there's a body and BodyParser hasn't consumed it.
+        result.merge!(rack_request.POST) if env.key?(RACK_INPUT) && !env.key?(ACTION_BODY_PARAMS)
 
         # Merge route params, then finally the BodyParser-parsed body (which wins on collisions).
         result.merge!(env[ROUTER_PARAMS]) if env.key?(ROUTER_PARAMS)

--- a/lib/hanami/action/params.rb
+++ b/lib/hanami/action/params.rb
@@ -345,24 +345,26 @@ module Hanami
 
       # @since 0.7.0
       # @api private
-      def _extract_params
+      def _extract_params # rubocop:disable Metrics/AbcSize
         result = {}
 
-        if env.key?(RACK_INPUT)
-          # If a body parser has already parsed the body, avoid double-parsing of the body by
-          # grabbing the query params only. Otherwise, let Rack parse both the query and body
-          # params, which covers ordinary application/x-www-form-urlencoded form posts.
-          if env.key?(ACTION_BODY_PARAMS) || env.key?(ROUTER_PARAMS)
-            result.merge! ::Rack::Request.new(env).GET
-          else
-            result.merge! ::Rack::Request.new(env).params
-          end
-
-          result.merge! _parsed_body_params
-        else
+        unless env.key?(RACK_INPUT)
           result.merge! _parsed_body_params(env)
           env[Action::REQUEST_METHOD] ||= Action::DEFAULT_REQUEST_METHOD
+          return result
         end
+
+        rack_request = ::Rack::Request.new(env)
+
+        # Start with the query string params.
+        result.merge!(rack_request.GET)
+
+        # Merge form-urlencoded body params if BodyParser hasn't already consumed the body.
+        result.merge!(rack_request.POST) unless env.key?(ACTION_BODY_PARAMS)
+
+        # Merge route params, then finally the BodyParser-parsed body (which wins on collisions).
+        result.merge!(env[ROUTER_PARAMS]) if env.key?(ROUTER_PARAMS)
+        result.merge!(env[ACTION_BODY_PARAMS]) if env.key?(ACTION_BODY_PARAMS)
 
         result
       end

--- a/spec/unit/hanami/action/body_parser_spec.rb
+++ b/spec/unit/hanami/action/body_parser_spec.rb
@@ -6,12 +6,13 @@ RSpec.describe Hanami::Action::BodyParser do
   let(:config) { Class.new(Hanami::Action).config }
 
   describe ".parse" do
-    it "skips if body already parsed" do
-      env = {"router.parsed_body" => {existing: "data"}}
+    it "reuses router-parsed body when present" do
+      env = {"router.parsed_body" => {"existing" => "data"}}
 
       described_class.parse(env, config)
 
-      expect(env["router.parsed_body"]).to eq(existing: "data")
+      expect(env["hanami.action.parsed_body"]).to eq("existing" => "data")
+      expect(env["hanami.action.body_params"]).to eq(existing: "data")
       expect(env).not_to have_key("router.params")
     end
 
@@ -20,7 +21,7 @@ RSpec.describe Hanami::Action::BodyParser do
 
       described_class.parse(env, config)
 
-      expect(env).not_to have_key("router.parsed_body")
+      expect(env).not_to have_key("hanami.action.parsed_body")
     end
 
     it "skips if no Content-Type header" do
@@ -28,7 +29,7 @@ RSpec.describe Hanami::Action::BodyParser do
 
       described_class.parse(env, config)
 
-      expect(env).not_to have_key("router.parsed_body")
+      expect(env).not_to have_key("hanami.action.parsed_body")
     end
 
     it "skips if Content-Type is empty" do
@@ -39,7 +40,7 @@ RSpec.describe Hanami::Action::BodyParser do
 
       described_class.parse(env, config)
 
-      expect(env).not_to have_key("router.parsed_body")
+      expect(env).not_to have_key("hanami.action.parsed_body")
     end
 
     it "skips non-multipart content types when no formats are configured" do
@@ -50,7 +51,7 @@ RSpec.describe Hanami::Action::BodyParser do
 
       described_class.parse(env, config)
 
-      expect(env).not_to have_key("router.parsed_body")
+      expect(env).not_to have_key("hanami.action.parsed_body")
     end
 
     it "parses multipart/form-data automatically when no formats are configured" do
@@ -71,8 +72,8 @@ RSpec.describe Hanami::Action::BodyParser do
 
       described_class.parse(env, config)
 
-      expect(env["router.parsed_body"]).to eq("title" => "My Title")
-      expect(env["router.params"]).to eq(title: "My Title")
+      expect(env["hanami.action.parsed_body"]).to eq("title" => "My Title")
+      expect(env["hanami.action.body_params"]).to eq(title: "My Title")
     end
 
     it "does not parse multipart/form-data automatically once any format is explicitly configured" do
@@ -95,7 +96,7 @@ RSpec.describe Hanami::Action::BodyParser do
 
       described_class.parse(env, config)
 
-      expect(env).not_to have_key("router.parsed_body")
+      expect(env).not_to have_key("hanami.action.parsed_body")
     end
 
     it "skips if content type not acceptable for configured formats" do
@@ -108,7 +109,7 @@ RSpec.describe Hanami::Action::BodyParser do
 
       described_class.parse(env, config)
 
-      expect(env).not_to have_key("router.parsed_body")
+      expect(env).not_to have_key("hanami.action.parsed_body")
     end
 
     it "skips if no parser registered for content type" do
@@ -122,7 +123,7 @@ RSpec.describe Hanami::Action::BodyParser do
 
       described_class.parse(env, config)
 
-      expect(env).not_to have_key("router.parsed_body")
+      expect(env).not_to have_key("hanami.action.parsed_body")
     end
 
     it "skips if body is empty" do
@@ -135,7 +136,7 @@ RSpec.describe Hanami::Action::BodyParser do
 
       described_class.parse(env, config)
 
-      expect(env).not_to have_key("router.parsed_body")
+      expect(env).not_to have_key("hanami.action.parsed_body")
     end
 
     context "with JSON request" do
@@ -149,11 +150,11 @@ RSpec.describe Hanami::Action::BodyParser do
 
         described_class.parse(env, config)
 
-        expect(env["router.parsed_body"]).to eq("name" => "Alice", "age" => 30)
-        expect(env["router.params"]).to eq(name: "Alice", age: 30)
+        expect(env["hanami.action.parsed_body"]).to eq("name" => "Alice", "age" => 30)
+        expect(env["hanami.action.body_params"]).to eq(name: "Alice", age: 30)
       end
 
-      it "preserves existing route params when parsing JSON" do
+      it "leaves existing router.params untouched when parsing JSON" do
         config.formats.accept :json
 
         env = {
@@ -164,8 +165,9 @@ RSpec.describe Hanami::Action::BodyParser do
 
         described_class.parse(env, config)
 
-        expect(env["router.parsed_body"]).to eq("comment" => {"body" => "hello"})
-        expect(env["router.params"]).to eq(slug: "my-article", comment: {body: "hello"})
+        expect(env["hanami.action.parsed_body"]).to eq("comment" => {"body" => "hello"})
+        expect(env["hanami.action.body_params"]).to eq(comment: {body: "hello"})
+        expect(env["router.params"]).to eq(slug: "my-article")
       end
 
       it "parses application/vnd.api+json" do
@@ -181,8 +183,8 @@ RSpec.describe Hanami::Action::BodyParser do
 
         described_class.parse(env, config)
 
-        expect(env["router.parsed_body"]).to eq("data" => {"type" => "articles"})
-        expect(env["router.params"]).to eq(data: {type: "articles"})
+        expect(env["hanami.action.parsed_body"]).to eq("data" => {"type" => "articles"})
+        expect(env["hanami.action.body_params"]).to eq(data: {type: "articles"})
       end
 
       it "strips charset from Content-Type" do
@@ -195,7 +197,7 @@ RSpec.describe Hanami::Action::BodyParser do
 
         described_class.parse(env, config)
 
-        expect(env["router.parsed_body"]).to eq("key" => "value")
+        expect(env["hanami.action.parsed_body"]).to eq("key" => "value")
       end
 
       it "handles nested objects" do
@@ -208,7 +210,7 @@ RSpec.describe Hanami::Action::BodyParser do
 
         described_class.parse(env, config)
 
-        expect(env["router.params"]).to eq(
+        expect(env["hanami.action.body_params"]).to eq(
           user: {
             name: "Alice",
             tags: ["ruby", "hanami"]
@@ -226,8 +228,8 @@ RSpec.describe Hanami::Action::BodyParser do
 
         described_class.parse(env, config)
 
-        expect(env["router.parsed_body"]).to eq([1, 2, 3])
-        expect(env["router.params"]).to eq(_: [1, 2, 3])
+        expect(env["hanami.action.parsed_body"]).to eq([1, 2, 3])
+        expect(env["hanami.action.body_params"]).to eq(_: [1, 2, 3])
       end
 
       it "handles non-hash JSON with nested hashes (arrays of objects)" do
@@ -240,8 +242,8 @@ RSpec.describe Hanami::Action::BodyParser do
 
         described_class.parse(env, config)
 
-        expect(env["router.parsed_body"]).to eq([{"name" => "Alice", "age" => 30}, {"name" => "Bob", "age" => 25}])
-        expect(env["router.params"]).to eq(_: [{name: "Alice", age: 30}, {name: "Bob", age: 25}])
+        expect(env["hanami.action.parsed_body"]).to eq([{"name" => "Alice", "age" => 30}, {"name" => "Bob", "age" => 25}])
+        expect(env["hanami.action.body_params"]).to eq(_: [{name: "Alice", age: 30}, {name: "Bob", age: 25}])
       end
     end
 
@@ -266,11 +268,11 @@ RSpec.describe Hanami::Action::BodyParser do
 
         described_class.parse(env, config)
 
-        expect(env["router.parsed_body"]).to eq("title" => "My Title")
-        expect(env["router.params"]).to eq(title: "My Title")
+        expect(env["hanami.action.parsed_body"]).to eq("title" => "My Title")
+        expect(env["hanami.action.body_params"]).to eq(title: "My Title")
       end
 
-      it "preserves existing route params when parsing multipart data" do
+      it "leaves existing router.params untouched when parsing multipart data" do
         config.formats.accept :html
 
         boundary = "----WebKitFormBoundary7MA4YWxkTrZu0gW"
@@ -291,8 +293,9 @@ RSpec.describe Hanami::Action::BodyParser do
 
         described_class.parse(env, config)
 
-        expect(env["router.parsed_body"]).to eq("title" => "My Title")
-        expect(env["router.params"]).to eq(slug: "my-article", title: "My Title")
+        expect(env["hanami.action.parsed_body"]).to eq("title" => "My Title")
+        expect(env["hanami.action.body_params"]).to eq(title: "My Title")
+        expect(env["router.params"]).to eq(slug: "my-article")
       end
 
       it "does not parse when only JSON accepted" do
@@ -315,7 +318,7 @@ RSpec.describe Hanami::Action::BodyParser do
 
         described_class.parse(env, config)
 
-        expect(env).not_to have_key("router.parsed_body")
+        expect(env).not_to have_key("hanami.action.parsed_body")
       end
     end
 
@@ -333,8 +336,8 @@ RSpec.describe Hanami::Action::BodyParser do
 
         described_class.parse(env, config)
 
-        expect(env["router.parsed_body"]).to eq("custom" => "parsed: test data")
-        expect(env["router.params"]).to eq(custom: "parsed: test data")
+        expect(env["hanami.action.parsed_body"]).to eq("custom" => "parsed: test data")
+        expect(env["hanami.action.body_params"]).to eq(custom: "parsed: test data")
       end
 
       it "uses directly registered parser" do
@@ -350,7 +353,7 @@ RSpec.describe Hanami::Action::BodyParser do
 
         described_class.parse(env, config)
 
-        expect(env["router.parsed_body"]).to eq("direct" => "HELLO")
+        expect(env["hanami.action.parsed_body"]).to eq("direct" => "HELLO")
       end
     end
 
@@ -365,7 +368,7 @@ RSpec.describe Hanami::Action::BodyParser do
 
         described_class.parse(env, config)
 
-        expect(env["router.parsed_body"]).to eq("key" => "value")
+        expect(env["hanami.action.parsed_body"]).to eq("key" => "value")
       end
 
       it "parses multipart when HTML format accepted along with JSON" do
@@ -388,7 +391,7 @@ RSpec.describe Hanami::Action::BodyParser do
 
         described_class.parse(env, config)
 
-        expect(env["router.parsed_body"]).to eq("field" => "value")
+        expect(env["hanami.action.parsed_body"]).to eq("field" => "value")
       end
     end
 
@@ -404,7 +407,7 @@ RSpec.describe Hanami::Action::BodyParser do
 
         described_class.parse(env, config)
 
-        expect(env["router.parsed_body"]).to eq("key" => "value")
+        expect(env["hanami.action.parsed_body"]).to eq("key" => "value")
         expect(input.pos).to eq(0) # Should be rewound
       end
 
@@ -424,7 +427,7 @@ RSpec.describe Hanami::Action::BodyParser do
           described_class.parse(env, config)
         }.not_to raise_error
 
-        expect(env["router.parsed_body"]).to eq("key" => "value")
+        expect(env["hanami.action.parsed_body"]).to eq("key" => "value")
       end
     end
   end

--- a/spec/unit/hanami/action/params_spec.rb
+++ b/spec/unit/hanami/action/params_spec.rb
@@ -82,6 +82,18 @@ RSpec.describe Hanami::Action::Params do
             expect(response.body).to eq(%({id: "23", x: {foo: "bar"}}))
           end
         end
+
+        it "returns only query params for bodyless GET requests" do
+          # Rack 3 omits rack.input for bodyless requests; env keys like REQUEST_METHOD,
+          # SERVER_NAME, etc. must not leak into the params.
+          response = Rack::MockRequest.new(action).request("GET", "/foo?id=23")
+
+          if RUBY_VERSION < "3.4"
+            expect(response.body).to eq(%({:id=>"23"}))
+          else
+            expect(response.body).to eq(%({id: "23"}))
+          end
+        end
       end
 
       context "with Hanami::Router" do

--- a/spec/unit/hanami/action/params_spec.rb
+++ b/spec/unit/hanami/action/params_spec.rb
@@ -95,19 +95,6 @@ RSpec.describe Hanami::Action::Params do
           end
         end
       end
-
-      context "with Hanami::Router" do
-        it "returns all the params as they are" do
-          # Hanami::Router params are always symbolized
-          response = action.call("router.params" => {id: "23"})
-
-          if RUBY_VERSION < "3.4"
-            expect(response.body).to eq([%({:id=>"23"})])
-          else
-            expect(response.body).to eq([%({id: "23"})])
-          end
-        end
-      end
     end
 
     context "when this feature is enabled" do
@@ -155,18 +142,6 @@ RSpec.describe Hanami::Action::Params do
             end
           end
         end
-
-        context "with Hanami::Router" do
-          it "returns only the listed params" do
-            response = action.call("router.params" => {id: 23, another: "x"})
-
-            if RUBY_VERSION < "3.4"
-              expect(response.body).to eq([%({:id=>23})])
-            else
-              expect(response.body).to eq([%({id: 23})])
-            end
-          end
-        end
       end
 
       context "with an anoymous class" do
@@ -197,18 +172,6 @@ RSpec.describe Hanami::Action::Params do
               expect(response.body).to match(%({:username=>"jodosha"}))
             else
               expect(response.body).to match(%({username: "jodosha"}))
-            end
-          end
-        end
-
-        context "with Hanami::Router" do
-          it "returns only the listed params" do
-            response = action.call("router.params" => {username: "jodosha", y: "x"})
-
-            if RUBY_VERSION < "3.4"
-              expect(response.body).to eq([%({:username=>"jodosha"})])
-            else
-              expect(response.body).to eq([%({username: "jodosha"})])
             end
           end
         end


### PR DESCRIPTION
This is a follow-up to the introduction of body parsing in #500, spurred on by the bug @cllns found and fixed in #508. Reviewing that fix, I realised that `Params#_extract_params` seemed over-complicated and hard to follow. As I dug in further, I found a number of opportunities to refactor, plus another bug to fix.

The changes here:

- Restructure `Params#_extract_params`: introduce a guard clause for the non-Rack (testing convenience) path, letting us have a flat, linear real Rack path with explicit precedence (query → form body → route params → BodyParser-parsed body). Split Rack's query/body parsing so form bodies are only read when `rack.input` is actually present.
- `Params#_extract_params` is now a pure reader — it no longer mutates env. The env `REQUEST_METHOD` default (needed by Response and other downstream code when tests pass a plain params hash) moves to `Action#call`, a more appropriate place for Rack env normalization. It's set after `Params.new` so the default doesn't land in params when env is used as a params hash in tests.
- Fix a pre-existing bug: bodyless GETs through Rack 3 omit `rack.input`, which caused the full Rack env (`REQUEST_METHOD`, `SERVER_NAME`, etc.) to be returned as `params.to_h`. The Rack-env discriminator now checks `PATH_INFO || rack.input`. Added a regression test to cover this.
- Give each Rack env key a single writer and meaning: BodyParser now writes only to `hanami.action.{parsed_body,body_params}`. The env keys previously set by Router-based body parsing are no longer preserved for compatibility — a more confident change here, and easier-to-follow code as a result.
- Drop the `{"router.params" => {...}}` hash-env test convention. Real Hanami::Router dispatches always produce full Rack envs, so the shortcut was unique to a few unit tests; integration coverage of route-params merging lives in `body_parser_route_params_spec`.

I've split this up into separate commits for easier review.