### PR TITLE
Performance: Cache action config as frozen Data snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
 ### Changed
 
 - Renamed gem from hanami-controller to hanami-action. You should now `require "hanami-action"` or `require "hanami/action"`. (@timriley in #507)
+- Cache the action's resolved configuration as a frozen `Data` snapshot (via dry-configurable's `#to_data`) at initialization, avoiding repeated config lookups on the request hot path for improved memory usage and speed. Required bumping `dry-configurable` to `~> 1.4`. (@cllns)
+
+  **Potentially breaking:** the action's config is now finalized (frozen) when the action is initialized, so mutating it from instance code (`config.handle_exception(...)`, `config.handled_exceptions = ...`, etc.) no longer works. This was previously possible only because `Action#initialize`'s `freeze` froze the instance shallowly without finalizing the config — instance-scope config mutation was an undocumented side effect, not a supported pattern. A downstream consequence is that `instance.config` is now a `Data` value object rather than the live `Hanami::Action::Config`, so `Config`-specific methods like `#handle_exception` aren't defined on instances; all setting readers (`config.formats`, `config.default_headers`, `config.default_charset`, etc.) work identically.
 
 ### Deprecated
 

--- a/hanami-action.gemspec
+++ b/hanami-action.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "rack", ">= 2.2.16"
   spec.add_runtime_dependency "hanami-utils", "~> 2.3.0"
-  spec.add_runtime_dependency "dry-configurable", "~> 1.0", "< 2"
+  spec.add_runtime_dependency "dry-configurable", "~> 1.4"
   spec.add_runtime_dependency "dry-core", "~> 1.0"
   spec.add_runtime_dependency "zeitwerk", "~> 2.6"
 end

--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -277,7 +277,15 @@ module Hanami
       config.handle_exception(...)
     end
 
-    # @since 2.0.0
+    # Returns the action's frozen `Data` snapshot of its resolved configuration.
+    #
+    # Instances expose `config` as a read-only `Data` value object (built via
+    # dry-configurable's `#to_data`), not the live `Hanami::Action::Config` used at the class
+    # level. All setting readers (`formats`, `default_headers`, `default_charset`, etc.) work
+    # exactly the same; Config-specific methods like `#handle_exception` are not available on
+    # instances and must be called on the class config instead.
+    #
+    # @since x.x.x
     # @api private
     private attr_reader :config
 
@@ -290,7 +298,8 @@ module Hanami
     # @since 2.0.0
     # @api public
     def initialize(config: self.class.config, contract: nil)
-      @config = config
+      config.finalize!
+      @config = config.to_data
       @contract = contract || config.contract_class&.new # TODO: tests showing this overridden by a dep
       freeze
     end

--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -298,8 +298,7 @@ module Hanami
     # @since 2.0.0
     # @api public
     def initialize(config: self.class.config, contract: nil)
-      config.finalize!
-      @config = config.to_data
+      @config = config.finalize!.to_data
       @contract = contract || config.contract_class&.new # TODO: tests showing this overridden by a dep
       freeze
     end


### PR DESCRIPTION
~30% fewer allocations and ~19% fewer bytes per `Action#call`.
~+49% iteration speed for both the minimal action and the formats + `Accept` path.

From using dry-configurable's new Config#to_data method, which was added in 1.4.0 https://github.com/dry-rb/dry-configurable/pull/167 Bumped the dependency accordingly.


**Speed**

| Scenario | IPS | μs/call | Speedup |
|---|---|---|---|
| `Action#call` (no formats), before | 75.7k | 13.21 | — |
| `Action#call` (no formats), after  | 112.7k | 8.87 | **1.49×** |
| `Action#call` (formats + `Accept`), before | 45.7k | 21.88 | — |
| `Action#call` (formats + `Accept`), after  | 67.9k | 14.73 | **1.49×** |

**Memory**

| Scenario | Allocations | Allocations saved | Bytes | Memory saved |
|---|---|---|---|---|
| `Action#call` (no formats), before | 75 | — | 5.54 kB | — |
| `Action#call` (no formats), after  | 51 | **32%** | 4.54 kB | **18%** |
| `Action#call` (formats + `Accept`), before | 134 | — | 8.30 kB | — |
| `Action#call` (formats + `Accept`), after  | 95  | **29%** | 6.70 kB | **19%** |

(Ruby 4.0.4, M1 Pro. Two representative actions: one minimal, one with `config.formats.accept :json` and a default header set, exercising the Mime negotiation hot path. Each action is instantiated once and reused — matching production usage where actions are container-managed singletons.)

## What changed

At initialization, the action's resolved configuration is now finalized and captured as a frozen `Data` snapshot via dry-configurable's `#to_data`:

```ruby
def initialize(config: self.class.config, contract: nil)
  config.finalize!
  @config = config.to_data
  ...
end
```

All per-request reads (`config.formats`, `config.default_headers`, `config.default_charset`, `config.before_callbacks`, `config.after_callbacks`, `config.handled_exceptions`, `config.default_tld_length`) now hit the `Data` value object instead of going through `Dry::Configurable::Config`'s method dispatch on every call.

This mirrors hanami/view#276.

## Potentially breaking

The action's config is now finalized (frozen) when the action is initialized, so mutating it from instance code (`config.handle_exception(...)`, `config.handled_exceptions = ...`, etc.) no longer works.

This was previously possible only because `Action#initialize`'s `freeze` froze the instance shallowly without finalizing the config... instance-scope config mutation was an undocumented side effect, not a supported pattern. None of the documented configuration patterns ([Exception handling](https://hanakai.org/learn/hanami/v2.3/actions/exception-handling), [Formats and media types](https://hanakai.org/learn/hanami/v2.3/actions/formats-and-media-types), [Control flow](https://hanakai.org/learn/hanami/v2.3/actions/control-flow), [Inheritance](https://hanakai.org/learn/hanami/v2.3/actions/inheritance)) use this; they all configure at the class body level.

A downstream consequence is that `instance.config` is now a `Data` value object rather than the live `Hanami::Action::Config`, so `Config`-specific methods like `#handle_exception` aren't defined on instances. All setting readers work identically because `Data` exposes the same readers and the underlying `Config::Formats` instance is shared.

I'd consider this unusual usage to not be breaking anyway, but we're bumping to 3.0 anyway so we should at least note it. I'm also fine taking it out of the changelog if desired.


## Reproducing the numbers

The benchmark scripts aren't shipped in this PR, but here's the IPS one inline:

<details>
<summary><code>benchmarks/action_call_ips.rb</code></summary>

```ruby
# frozen_string_literal: true

require "hanami/action"
require "benchmark/ips"

class HelloAction < Hanami::Action
  config.formats.accept :json
  config.default_headers = {"X-Frame-Options" => "DENY"}

  def handle(_req, res)
    res.body = "hello"
  end
end

class MinimalAction < Hanami::Action
  def handle(_req, res)
    res.body = "hello"
  end
end

MINIMAL_ACTION = MinimalAction.new
HELLO_ACTION = HelloAction.new

ENV_NO_ACCEPT = {
  "REQUEST_METHOD" => "GET",
  "PATH_INFO" => "/",
  "QUERY_STRING" => ""
}.freeze

ENV_WITH_ACCEPT = ENV_NO_ACCEPT.merge("HTTP_ACCEPT" => "application/json").freeze

Benchmark.ips do |x|
  x.report("Action#call (no formats)") do
    MINIMAL_ACTION.call(ENV_NO_ACCEPT.dup)
  end

  x.report("Action#call (with formats + Accept)") do
    HELLO_ACTION.call(ENV_WITH_ACCEPT.dup)
  end

  x.compare!
end
```

Swap `Benchmark.ips` for a `MemoryProfiler.report { ... }` to get the allocation/byte numbers.
</details>
