### PR TITLE
Remove Params.params and subclass-based contract definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,28 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
 
 ### Removed
 
+- Removed `Hanami::Action::Params.params` and support for defining a contract by subclassing `Hanami::Action::Params`. If you are subclassing `Hanami::Action::Params`, take your params block and move it into a `Dry::Validation::Contract` subclass.  Then pass this contract class to `Hanami::Action.params` or `Hanami::Action.contract`. (@timriley)
+
+  ```ruby
+  # Before
+  # class SignupParams < Hanami::Action::Params
+  #   params do
+  #     required(:email).filled(:str?)
+  #   end
+  # end
+  
+  # After
+  class SignupContract < Dry::Validation::Contract
+    params do
+      required(:email).filled(:str?)
+    end
+  end
+  
+  class Signup < Hanami::Action
+    params SignupParams
+  end
+  ```
+
 ### Fixed
 
 ### Security

--- a/lib/hanami/action/params.rb
+++ b/lib/hanami/action/params.rb
@@ -131,29 +131,6 @@ module Hanami
         end
       end
 
-      # Defines validations for the params, using the `params` schema of a dry-validation contract.
-      #
-      # @param block [Proc] the schema definition
-      #
-      # @see https://dry-rb.org/gems/dry-validation/
-      #
-      # @api public
-      # @since 0.7.0
-      def self.params(&block)
-        unless defined?(Dry::Validation::Contract)
-          message = %(To use `.params`, please add the "dry-validation" gem to your Gemfile)
-          raise NoMethodError, message
-        end
-
-        @_contract = Class.new(Dry::Validation::Contract) { params(&block || -> {}) }.new
-      end
-
-      class << self
-        # @api private
-        # @since 2.2.0
-        attr_reader :_contract
-      end
-
       # @attr_reader env [Hash] the Rack env
       #
       # @since 0.7.0
@@ -195,10 +172,7 @@ module Hanami
         @env = env
         @raw = _extract_params
 
-        # Fall back to the default contract here, rather than in the `._contract` method itself.
-        # This allows `._contract` to return nil when there is no user-defined contract, which is
-        # important for the backwards compatibility behavior in `Validatable::ClassMethods#params`.
-        contract ||= self.class._contract || DefaultContract
+        contract ||= DefaultContract
         validation = contract.call(raw)
 
         @params = validation.to_h

--- a/lib/hanami/action/validatable.rb
+++ b/lib/hanami/action/validatable.rb
@@ -9,12 +9,6 @@ module Hanami
     # @api private
     # @since 0.1.0
     module Validatable
-      # Defines the class name for anonymous params
-      #
-      # @api private
-      # @since 0.3.0
-      PARAMS_CLASS_NAME = "Params"
-
       # @api private
       # @since 0.1.0
       def self.included(base)
@@ -36,13 +30,10 @@ module Hanami
         # class. This constrains the validation to simple structure and type rules only. If you want
         # to use all the features of dry-validation contracts, use {#contract} instead.
         #
-        # The resulting contract becomes part of a dedicated params class for the action, inheriting
-        # from {Hanami::Action::Params}.
-        #
         # Instead of defining the params validation schema inline, you can alternatively provide a
-        # concrete params class, which should inherit from {Hanami::Action::Params}.
+        # concrete `Dry::Validation::Contract` subclass.
         #
-        # @param klass [Class,nil] a Hanami::Action::Params subclass
+        # @param klass [Class,nil] a Dry::Validation::Contract subclass
         # @param block [Proc] the params schema definition
         #
         # @return void
@@ -62,9 +53,6 @@ module Hanami
         #     end
         #
         #     def handle(req, *)
-        #       puts req.params.class            # => Signup::Params
-        #       puts req.params.class.superclass # => Hanami::Action::Params
-        #
         #       puts req.params[:first_name]     # => "Luca"
         #       puts req.params[:admin]          # => nil
         #     end
@@ -73,7 +61,7 @@ module Hanami
         # @example Concrete class
         #   require "hanami/action"
         #
-        #   class SignupParams < Hanami::Action::Params
+        #   class SignupContract < Dry::Validation::Contract
         #     params do
         #       required(:first_name)
         #       required(:last_name)
@@ -82,12 +70,9 @@ module Hanami
         #   end
         #
         #   class Signup < Hanami::Action
-        #     params SignupParams
+        #     params SignupContract
         #
         #     def handle(req, *)
-        #       puts req.params.class            # => SignupParams
-        #       puts req.params.class.superclass # => Hanami::Action::Params
-        #
         #       req.params[:first_name]          # => "Luca"
         #       req.params[:admin]               # => nil
         #     end
@@ -96,15 +81,7 @@ module Hanami
         # @api public
         # @since 0.3.0
         def params(klass = nil, &block)
-          contract_class =
-            if klass.nil?
-              Class.new(Dry::Validation::Contract) { params(&block) }
-            elsif klass < Params
-              # Handle subclasses of Hanami::Action::Params.
-              klass._contract.class
-            else
-              klass
-            end
+          contract_class = klass || Class.new(Dry::Validation::Contract) { params(&block) }
 
           config.contract_class = contract_class
         end
@@ -118,13 +95,10 @@ module Hanami
         # The given block is evaluated inside a `Dry::Validation::Contract` class. This allows you
         # to use all features of dry-validation contracts
         #
-        # The resulting contract becomes part of a dedicated params class for the action, inheriting
-        # from {Hanami::Action::Params}.
+        # Instead of defining the contract inline, you can alternatively provide a concrete
+        # `Dry::Validation::Contract` subclass.
         #
-        # Instead of defining the params validation contract inline, you can alternatively provide a
-        # concrete params class, which should inherit from {Hanami::Action::Params}.
-        #
-        # @param klass [Class,nil] a Hanami::Action::Params subclass
+        # @param klass [Class,nil] a Dry::Validation::Contract subclass
         # @param block [Proc] the params schema definition
         #
         # @return void
@@ -150,9 +124,6 @@ module Hanami
         #     end
         #
         #     def handle(req, *)
-        #       puts req.params.class            # => Signup::Params
-        #       puts req.params.class.superclass # => Hanami::Action::Params
-        #
         #       puts req.params[:first_name]     # => "Luca"
         #       puts req.params[:admin]          # => nil
         #     end
@@ -161,27 +132,22 @@ module Hanami
         # @example Concrete class
         #   require "hanami/action"
         #
-        #   class SignupParams < Hanami::Action::Params
-        #     contract do
-        #       params do
-        #         required(:first_name)
-        #         required(:last_name)
-        #         required(:email)
-        #       end
+        #   class SignupContract < Dry::Validation::Contract
+        #     params do
+        #       required(:first_name)
+        #       required(:last_name)
+        #       required(:email)
+        #     end
         #
-        #       rule(:email) do
-        #         # custom rule logic here
-        #       end
+        #     rule(:email) do
+        #       # custom rule logic here
         #     end
         #   end
         #
         #   class Signup < Hanami::Action
-        #     params SignupParams
+        #     contract SignupContract
         #
         #     def handle(req, *)
-        #       puts req.params.class            # => SignupParams
-        #       puts req.params.class.superclass # => Hanami::Action::Params
-        #
         #       req.params[:first_name]          # => "Luca"
         #       req.params[:admin]               # => nil
         #     end

--- a/spec/isolation/without_dry_validation_spec.rb
+++ b/spec/isolation/without_dry_validation_spec.rb
@@ -39,19 +39,6 @@ RSpec.describe "Without validations" do
     )
   end
 
-  it "doesn't have Hanami::Action::Params.params" do
-    expect do
-      Class.new(Hanami::Action::Params) do
-        params do
-          required(:id).filled
-        end
-      end
-    end.to raise_error(
-      NoMethodError,
-      %(To use `.params`, please add the "dry-validation" gem to your Gemfile)
-    )
-  end
-
   it "has params that are always valid" do
     action = Class.new(Hanami::Action) do
       def handle(req, res)

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -616,17 +616,13 @@ class ParamsAction < Hanami::Action
 end
 
 class AllowlistedParamsAction < Hanami::Action
-  class Params < Hanami::Action::Params
-    params do
-      required(:id).maybe(:integer)
+  params do
+    required(:id).maybe(:integer)
 
-      required(:article).schema do
-        required(:tags).each(:str?)
-      end
+    required(:article).schema do
+      required(:tags).each(:str?)
     end
   end
-
-  params Params
 
   def handle(req, res)
     res.body = req.params.to_h.inspect
@@ -664,7 +660,7 @@ class ParamsValidationAction < Hanami::Action
   end
 end
 
-class TestParams < Hanami::Action::Params
+class TestContract < Dry::Validation::Contract
   params do
     required(:email).filled(format?: /\A.+@.+\z/)
 
@@ -692,7 +688,7 @@ class TestParams < Hanami::Action::Params
   end
 end
 
-class NestedParams < Hanami::Action::Params
+class NestedContract < Dry::Validation::Contract
   params do
     required(:signup).schema do
       required(:name).filled(:str?)

--- a/spec/unit/hanami/action/params_spec.rb
+++ b/spec/unit/hanami/action/params_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe Hanami::Action::Params do
 
   describe "validations" do
     it "isn't valid with empty params" do
-      params = TestParams.new(env: {})
+      params = Hanami::Action::Params.new(contract: TestContract.new, env: {})
 
       expect(params.valid?).to be(false)
 
@@ -194,7 +194,7 @@ RSpec.describe Hanami::Action::Params do
     end
 
     it "isn't valid with empty nested params" do
-      params = NestedParams.new(env: {signup: {}})
+      params = Hanami::Action::Params.new(env: {signup: {}}, contract: NestedContract.new)
 
       expect(params.valid?).to be(false)
 
@@ -204,7 +204,8 @@ RSpec.describe Hanami::Action::Params do
     end
 
     it "is it valid when all the validation criteria are met" do
-      params = TestParams.new(
+      params = Hanami::Action::Params.new(
+        contract: TestContract.new,
         env: {
           email: "test@hanamirb.org",
           password: "123456",
@@ -227,7 +228,7 @@ RSpec.describe Hanami::Action::Params do
     end
 
     it "has input available through the hash accessor" do
-      params = TestParams.new(env: {name: "John", age: "1", address: {line_one: "10 High Street"}})
+      params = Hanami::Action::Params.new(contract: TestContract.new, env: {name: "John", age: "1", address: {line_one: "10 High Street"}})
 
       expect(params[:name]).to               eq("John")
       expect(params[:age]).to                be(1)
@@ -235,7 +236,7 @@ RSpec.describe Hanami::Action::Params do
     end
 
     it "allows nested hash access via symbols" do
-      params = TestParams.new(env: {name: "John", address: {line_one: "10 High Street", deep: {deep_attr: 1}}})
+      params = Hanami::Action::Params.new(contract: TestContract.new, env: {name: "John", address: {line_one: "10 High Street", deep: {deep_attr: 1}}})
       expect(params[:name]).to                       eq("John")
       expect(params[:address][:line_one]).to         eq("10 High Street")
       expect(params[:address][:deep][:deep_attr]).to be(1)
@@ -245,7 +246,8 @@ RSpec.describe Hanami::Action::Params do
   describe "#get" do
     context "with data" do
       let(:params) do
-        TestParams.new(
+        Hanami::Action::Params.new(
+          contract: TestContract.new,
           env: {
             name: "John",
             address: {line_one: "10 High Street", deep: {deep_attr: 1}},
@@ -281,7 +283,7 @@ RSpec.describe Hanami::Action::Params do
     end
 
     context "without data" do
-      let(:params) { TestParams.new(env: {}) }
+      let(:params) { Hanami::Action::Params.new(contract: TestContract.new, env: {}) }
 
       it "returns nil for nil argument" do
         expect(params.get(nil)).to be(nil)
@@ -306,7 +308,7 @@ RSpec.describe Hanami::Action::Params do
   end
 
   describe "#to_h" do
-    let(:params) { TestParams.new(env: {name: "Jane"}) }
+    let(:params) { Hanami::Action::Params.new(contract: TestContract.new, env: {name: "Jane"}) }
 
     it "returns a ::Hash" do
       expect(params.to_h).to be_kind_of(::Hash)
@@ -341,7 +343,7 @@ RSpec.describe Hanami::Action::Params do
         }
       }
 
-      actual = TestParams.new(env: input).to_h
+      actual = Hanami::Action::Params.new(contract: TestContract.new, env: input).to_h
       expect(actual).to eq(expected)
 
       expect(actual).to                  be_kind_of(::Hash)
@@ -374,7 +376,7 @@ RSpec.describe Hanami::Action::Params do
           }
         }
 
-        actual = TestParams.new(env: input).to_h
+        actual = Hanami::Action::Params.new(contract: TestContract.new, env: input).to_h
         expect(actual).to eq(expected)
 
         expect(actual).to                  be_kind_of(::Hash)
@@ -385,7 +387,7 @@ RSpec.describe Hanami::Action::Params do
   end
 
   describe "#to_hash" do
-    let(:params) { TestParams.new(env: {name: "Jane"}) }
+    let(:params) { Hanami::Action::Params.new(contract: TestContract.new, env: {name: "Jane"}) }
 
     it "returns a ::Hash" do
       expect(params.to_hash).to be_kind_of(::Hash)
@@ -420,7 +422,7 @@ RSpec.describe Hanami::Action::Params do
         }
       }
 
-      actual = TestParams.new(env: input).to_hash
+      actual = Hanami::Action::Params.new(contract: TestContract.new, env: input).to_hash
       expect(actual).to eq(expected)
 
       expect(actual).to                  be_kind_of(::Hash)
@@ -453,7 +455,7 @@ RSpec.describe Hanami::Action::Params do
           }
         }
 
-        actual = TestParams.new(env: input).to_hash
+        actual = Hanami::Action::Params.new(contract: TestContract.new, env: input).to_hash
         expect(actual).to eq(expected)
 
         expect(actual).to                  be_kind_of(::Hash)
@@ -463,7 +465,7 @@ RSpec.describe Hanami::Action::Params do
 
       it "does not stringify values" do
         input  = {"name" => 123}
-        params = TestParams.new(env: input)
+        params = Hanami::Action::Params.new(contract: TestContract.new, env: input)
 
         expect(params[:name]).to be(123)
       end
@@ -472,7 +474,8 @@ RSpec.describe Hanami::Action::Params do
 
   describe "#deconstruct_keys" do
     let(:params) do
-      TestParams.new(
+      Hanami::Action::Params.new(
+        contract: TestContract.new,
         env: {
           name: "John",
           address: {line_one: "10 High Street", deep: {deep_attr: 1}},
@@ -488,17 +491,17 @@ RSpec.describe Hanami::Action::Params do
   end
 
   describe "#errors" do
-    let(:klass) do
-      Class.new(described_class) do
+    let(:contract) do
+      Class.new(Dry::Validation::Contract) do
         params do
           required(:book).schema do
             required(:code).filled(:str?)
           end
         end
-      end
+      end.new
     end
 
-    let(:params) { klass.new(env: {book: {code: "abc"}}) }
+    let(:params) { described_class.new(env: {book: {code: "abc"}}, contract: contract) }
 
     it "returns Hanami::Action::Params::Errors" do
       expect(params.errors).to be_kind_of(Hanami::Action::Params::Errors)
@@ -512,7 +515,7 @@ RSpec.describe Hanami::Action::Params do
     end
 
     it "appends message to already existing messages" do
-      params = klass.new(env: {book: {}})
+      params = described_class.new(env: {book: {}}, contract: contract)
       params.errors.add(:book, :code, "is invalid")
 
       expect(params.error_messages).to eq(["Code is missing", "Code is invalid"])
@@ -524,7 +527,7 @@ RSpec.describe Hanami::Action::Params do
     end
 
     it "raises error when try to add an error " do
-      params = klass.new(env: {})
+      params = described_class.new(env: {}, contract: contract)
 
       if RUBY_VERSION < "3.4"
         expect { params.errors.add(:book, :code, "is invalid") }.to raise_error(


### PR DESCRIPTION
This was a legacy approach and has not been recommended since we introduced integration with Dry Validation. Users with `Hanami::Action::Params` subclasses should instead move that schema to a Dry Validation contract and pass the contract class to `Hanami::Action.params` or `Hanami::Action.contract`.

Fixes #455