### PR TITLE
Relocate body parsers, allow eager loading

### DIFF
--- a/lib/hanami/action.rb
+++ b/lib/hanami/action.rb
@@ -44,7 +44,10 @@ module Hanami
           "#{root}/hanami/action/version.rb",
           "#{root}/hanami/action/{constants,errors,rack_utils,validatable}.rb"
         )
-        loader.inflector.inflect("csrf_protection" => "CSRFProtection")
+        loader.inflector.inflect(
+          "csrf_protection" => "CSRFProtection",
+          "json" => "JSON"
+        )
       end
     end
 

--- a/lib/hanami/action/body_parser/json.rb
+++ b/lib/hanami/action/body_parser/json.rb
@@ -1,16 +1,15 @@
 # frozen_string_literal: true
 
 require "json"
-require_relative "../errors"
 
 module Hanami
   class Action
-    module BodyParsers
+    module BodyParser
       # Body parser for JSON request bodies.
       #
       # @api private
       module JSON
-        def self.call(body, env)
+        def self.call(body, _env)
           ::JSON.parse(body)
         rescue ::JSON::ParserError => exception
           raise BodyParsingError, exception.message

--- a/lib/hanami/action/body_parser/multipart_form.rb
+++ b/lib/hanami/action/body_parser/multipart_form.rb
@@ -1,16 +1,15 @@
 # frozen_string_literal: true
 
 require "rack/multipart"
-require_relative "../errors"
 
 module Hanami
   class Action
-    module BodyParsers
+    module BodyParser
       # Body parser for multipart form data (file uploads).
       #
       # @api private
       module MultipartForm
-        def self.call(body, env)
+        def self.call(_body, env)
           # Rack's `parse_multipart` reads the input from the env. We've already rewound this input
           # in BodyParser, before this parser is called.
           ::Rack::Multipart.parse_multipart(env)

--- a/lib/hanami/action/config/formats.rb
+++ b/lib/hanami/action/config/formats.rb
@@ -243,15 +243,12 @@ module Hanami
         private
 
         def register_default_body_parsers
-          require_relative "../body_parsers/json"
-          require_relative "../body_parsers/multipart_form"
-
           # Multipart forms (ordinary urlencoded forms are handled by Rack automatically)
-          @body_parsers["multipart/form-data"] = BodyParsers::MultipartForm
+          @body_parsers["multipart/form-data"] = BodyParser::MultipartForm
 
           # JSON
-          @body_parsers["application/json"] = BodyParsers::JSON
-          @body_parsers["application/vnd.api+json"] = BodyParsers::JSON
+          @body_parsers["application/json"] = BodyParser::JSON
+          @body_parsers["application/vnd.api+json"] = BodyParser::JSON
         end
       end
     end

--- a/spec/unit/hanami/action/body_parser/json_spec.rb
+++ b/spec/unit/hanami/action/body_parser/json_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Hanami::Action::BodyParsers::JSON, ".call" do
+RSpec.describe Hanami::Action::BodyParser::JSON, ".call" do
   it "parses valid JSON" do
     body = '{"user":{"name":"Alice","address":{"city":"Rome"}}}'
     result = described_class.call(body, {})

--- a/spec/unit/hanami/action/body_parser/multipart_form_spec.rb
+++ b/spec/unit/hanami/action/body_parser/multipart_form_spec.rb
@@ -2,7 +2,7 @@
 
 require "stringio"
 
-RSpec.describe Hanami::Action::BodyParsers::MultipartForm, ".call" do
+RSpec.describe Hanami::Action::BodyParser::MultipartForm, ".call" do
   it "parses multipart form data" do
     boundary = "----WebKitFormBoundary7MA4YWxkTrZu0gW"
     body = [

--- a/spec/unit/hanami/action/config/formats_spec.rb
+++ b/spec/unit/hanami/action/config/formats_spec.rb
@@ -92,12 +92,12 @@ RSpec.describe Hanami::Action::Config::Formats do
     end
 
     it "includes default parsers for JSON" do
-      expect(formats.body_parser_for("application/json")).to eq(Hanami::Action::BodyParsers::JSON)
-      expect(formats.body_parser_for("application/vnd.api+json")).to eq(Hanami::Action::BodyParsers::JSON)
+      expect(formats.body_parser_for("application/json")).to eq(Hanami::Action::BodyParser::JSON)
+      expect(formats.body_parser_for("application/vnd.api+json")).to eq(Hanami::Action::BodyParser::JSON)
     end
 
     it "includes default parser for multipart forms" do
-      expect(formats.body_parser_for("multipart/form-data")).to eq(Hanami::Action::BodyParsers::MultipartForm)
+      expect(formats.body_parser_for("multipart/form-data")).to eq(Hanami::Action::BodyParser::MultipartForm)
     end
   end
 
@@ -105,7 +105,7 @@ RSpec.describe Hanami::Action::Config::Formats do
     it "returns parser for registered content type" do
       parser = formats.body_parser_for("application/json")
 
-      expect(parser).to eq(Hanami::Action::BodyParsers::JSON)
+      expect(parser).to eq(Hanami::Action::BodyParser::JSON)
     end
 
     it "returns nil for unregistered content type" do
@@ -115,7 +115,7 @@ RSpec.describe Hanami::Action::Config::Formats do
     it "is case-insensitive" do
       parser = formats.body_parser_for("APPLICATION/JSON")
 
-      expect(parser).to eq(Hanami::Action::BodyParsers::JSON)
+      expect(parser).to eq(Hanami::Action::BodyParser::JSON)
     end
 
     it "handles nil content type" do


### PR DESCRIPTION
Add a Zeitwerk inflection rule (for `"JSON"`) to allow our body parsers to be eager loaded.

At the same time, bring them into a namespace under the main `BodyParser` module to avoid having two too-similarly-named modules (`BodyParser` and `BodyParsers`).