### PR TITLE
Fix multipart CSRF: keep body params string-keyed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,13 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
 
 ### Added
 
-- Parse request bodies based on formats config. (@timriley in #500, #503, #511, @cllns in #508)
+- Parse request bodies based on formats config. (@timriley in #500, #503, #511, #519, @cllns in #508)
 
     Parsers for multipart form bodies and JSON are included by default. These require `formats.accept :html` and `formats.accept :json` respectively. When no formats are configured, multipart form bodies are parsed if found.
 
     Custom parsers may be registered via e.g. `formats.register(:custom, "application/custom", parser: ->(body, env) { ... })` or directly via `formats.body_parsers["application/custom"] = parser`.
 
-    Parsed body keys are deeply symbolized. Non-hash bodies are wrapped in `{_: parsed_body}`.
+    Parsed body params are symbolized as part of becoming the `Hanami::Action::Params` instance. Non-hash bodies are wrapped in `{"_" => parsed_body}`.
 - Full JRuby support. (@katafrakt in #498)
 
 ### Changed

--- a/lib/hanami/action/body_parser.rb
+++ b/lib/hanami/action/body_parser.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "rack"
-require "hanami/utils/hash"
 
 module Hanami
   class Action
@@ -9,7 +8,7 @@ module Hanami
     #
     # @api private
     module BodyParser
-      FALLBACK_KEY = :_
+      FALLBACK_KEY = "_"
 
       class << self
         # rubocop:disable Metrics/AbcSize, Metrics/PerceivedComplexity
@@ -25,7 +24,7 @@ module Hanami
           if env.key?(ROUTER_PARSED_BODY)
             parsed = env[ROUTER_PARSED_BODY]
             env[ACTION_PARSED_BODY] = parsed
-            env[ACTION_BODY_PARAMS] = symbolize_body(parsed)
+            env[ACTION_BODY_PARAMS] = body_params(parsed)
             return
           end
 
@@ -59,7 +58,7 @@ module Hanami
           parsed = parser.call(body, env)
 
           env[ACTION_PARSED_BODY] = parsed
-          env[ACTION_BODY_PARAMS] = symbolize_body(parsed)
+          env[ACTION_BODY_PARAMS] = body_params(parsed)
         end
 
         # rubocop:enable Metrics/AbcSize, Metrics/PerceivedComplexity
@@ -83,25 +82,12 @@ module Hanami
           body
         end
 
-        # Symbolizes the parsed body, wrapping non-hash values in a fallback key.
-        def symbolize_body(parsed)
-          if parsed.is_a?(::Hash)
-            deep_symbolize(parsed)
-          else
-            {FALLBACK_KEY => deep_symbolize(parsed)}
-          end
-        end
-
-        # Recursively symbolizes hash keys within any structure (arrays or hashes).
-        def deep_symbolize(value)
-          case value
-          when ::Hash
-            Utils::Hash.deep_symbolize(value)
-          when ::Array
-            value.map { deep_symbolize(_1) }
-          else
-            value
-          end
+        # Wraps a parsed body into a hash suitable for merging into params.
+        #
+        # Hash bodies are returned as-is; non-hash bodies (e.g. JSON arrays) are wrapped under
+        # {FALLBACK_KEY}. Keys are left as strings. Symbolization happens in {Params}.
+        def body_params(parsed)
+          parsed.is_a?(::Hash) ? parsed : {FALLBACK_KEY => parsed}
         end
       end
     end

--- a/lib/hanami/action/constants.rb
+++ b/lib/hanami/action/constants.rb
@@ -235,34 +235,40 @@ module Hanami
     # @api private
     RACK_INPUT = ::Rack::RACK_INPUT
 
-    # The key that returns a request body parsed by Hanami Action.
+    # The key that holds the body parser's verbatim output for the request.
     #
-    # This is the canonical key for body parsing.
+    # This holds whatever the parser returned, and may be any type (a hash for most bodies, but
+    # possibly an array or scalar for JSON bodies). It mirrors the router's {ROUTER_PARSED_BODY} as
+    # the faithful representation of the parsed body.
     #
-    # @since x.x.x
+    # For the params-ready form (always a hash, with keys merged into the request params), see
+    # {ACTION_BODY_PARAMS}.
+    #
     # @api private
     ACTION_PARSED_BODY = "hanami.action.parsed_body"
 
-    # The key that returns params from a parsed body by Hanami Action.
+    # The key that holds the parsed body normalized into a hash for merging into the request params.
     #
-    # This is the canonical key for parsed body params.
+    # Hash bodies keep the string keys sent by the client; these are symbolized later by
+    # {Hanami::Action::Params}.. Non-Hash bodies (such as a top-level JSON array) are wrapped under
+    # `"_"` so they can still be merged.
     #
-    # @since x.x.x
+    # For the parser's verbatim (possibly non-hash) output, see {ACTION_PARSED_BODY}.
+    #
     # @api private
     ACTION_BODY_PARAMS = "hanami.action.body_params"
 
     # The key that returns a request body parsed by Hanami Router.
     #
-    # This is maintained for backward compatibility with Hanami Router.
+    # This is maintained for compatibility with Hanami Router's body parser middlware.
     #
     # @api private
     ROUTER_PARSED_BODY = "router.parsed_body"
 
     # The key that returns router params from the Rack env.
     #
-    # This is maintained for backward compatibility with Hanami Router.
+    # This is maintained for compatibility with Hanami Router's body parser middlware.
     #
-    # @since 2.0.0
     # @api private
     ROUTER_PARAMS = "router.params"
 

--- a/spec/unit/hanami/action/body_parser_spec.rb
+++ b/spec/unit/hanami/action/body_parser_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Hanami::Action::BodyParser do
       described_class.parse(env, config)
 
       expect(env["hanami.action.parsed_body"]).to eq("existing" => "data")
-      expect(env["hanami.action.body_params"]).to eq(existing: "data")
+      expect(env["hanami.action.body_params"]).to eq("existing" => "data")
       expect(env).not_to have_key("router.params")
     end
 
@@ -73,7 +73,7 @@ RSpec.describe Hanami::Action::BodyParser do
       described_class.parse(env, config)
 
       expect(env["hanami.action.parsed_body"]).to eq("title" => "My Title")
-      expect(env["hanami.action.body_params"]).to eq(title: "My Title")
+      expect(env["hanami.action.body_params"]).to eq("title" => "My Title")
     end
 
     it "does not parse multipart/form-data automatically once any format is explicitly configured" do
@@ -151,7 +151,7 @@ RSpec.describe Hanami::Action::BodyParser do
         described_class.parse(env, config)
 
         expect(env["hanami.action.parsed_body"]).to eq("name" => "Alice", "age" => 30)
-        expect(env["hanami.action.body_params"]).to eq(name: "Alice", age: 30)
+        expect(env["hanami.action.body_params"]).to eq("name" => "Alice", "age" => 30)
       end
 
       it "leaves existing router.params untouched when parsing JSON" do
@@ -166,7 +166,7 @@ RSpec.describe Hanami::Action::BodyParser do
         described_class.parse(env, config)
 
         expect(env["hanami.action.parsed_body"]).to eq("comment" => {"body" => "hello"})
-        expect(env["hanami.action.body_params"]).to eq(comment: {body: "hello"})
+        expect(env["hanami.action.body_params"]).to eq("comment" => {"body" => "hello"})
         expect(env["router.params"]).to eq(slug: "my-article")
       end
 
@@ -184,7 +184,7 @@ RSpec.describe Hanami::Action::BodyParser do
         described_class.parse(env, config)
 
         expect(env["hanami.action.parsed_body"]).to eq("data" => {"type" => "articles"})
-        expect(env["hanami.action.body_params"]).to eq(data: {type: "articles"})
+        expect(env["hanami.action.body_params"]).to eq("data" => {"type" => "articles"})
       end
 
       it "strips charset from Content-Type" do
@@ -211,9 +211,9 @@ RSpec.describe Hanami::Action::BodyParser do
         described_class.parse(env, config)
 
         expect(env["hanami.action.body_params"]).to eq(
-          user: {
-            name: "Alice",
-            tags: ["ruby", "hanami"]
+          "user" => {
+            "name" => "Alice",
+            "tags" => ["ruby", "hanami"]
           }
         )
       end
@@ -229,7 +229,7 @@ RSpec.describe Hanami::Action::BodyParser do
         described_class.parse(env, config)
 
         expect(env["hanami.action.parsed_body"]).to eq([1, 2, 3])
-        expect(env["hanami.action.body_params"]).to eq(_: [1, 2, 3])
+        expect(env["hanami.action.body_params"]).to eq("_" => [1, 2, 3])
       end
 
       it "handles non-hash JSON with nested hashes (arrays of objects)" do
@@ -243,7 +243,7 @@ RSpec.describe Hanami::Action::BodyParser do
         described_class.parse(env, config)
 
         expect(env["hanami.action.parsed_body"]).to eq([{"name" => "Alice", "age" => 30}, {"name" => "Bob", "age" => 25}])
-        expect(env["hanami.action.body_params"]).to eq(_: [{name: "Alice", age: 30}, {name: "Bob", age: 25}])
+        expect(env["hanami.action.body_params"]).to eq("_" => [{"name" => "Alice", "age" => 30}, {"name" => "Bob", "age" => 25}])
       end
     end
 
@@ -269,7 +269,7 @@ RSpec.describe Hanami::Action::BodyParser do
         described_class.parse(env, config)
 
         expect(env["hanami.action.parsed_body"]).to eq("title" => "My Title")
-        expect(env["hanami.action.body_params"]).to eq(title: "My Title")
+        expect(env["hanami.action.body_params"]).to eq("title" => "My Title")
       end
 
       it "leaves existing router.params untouched when parsing multipart data" do
@@ -294,7 +294,7 @@ RSpec.describe Hanami::Action::BodyParser do
         described_class.parse(env, config)
 
         expect(env["hanami.action.parsed_body"]).to eq("title" => "My Title")
-        expect(env["hanami.action.body_params"]).to eq(title: "My Title")
+        expect(env["hanami.action.body_params"]).to eq("title" => "My Title")
         expect(env["router.params"]).to eq(slug: "my-article")
       end
 
@@ -337,7 +337,7 @@ RSpec.describe Hanami::Action::BodyParser do
         described_class.parse(env, config)
 
         expect(env["hanami.action.parsed_body"]).to eq("custom" => "parsed: test data")
-        expect(env["hanami.action.body_params"]).to eq(custom: "parsed: test data")
+        expect(env["hanami.action.body_params"]).to eq("custom" => "parsed: test data")
       end
 
       it "uses directly registered parser" do

--- a/spec/unit/hanami/action/params_spec.rb
+++ b/spec/unit/hanami/action/params_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Hanami::Action::Params do
   describe "#raw" do
     let(:params) { Class.new(Hanami::Action::Params) }
 
-    context "when this feature isn't enabled" do
+    context "when no params schema is defined" do
       let(:action) { ParamsAction.new }
 
       it "raw gets all params" do
@@ -26,7 +26,7 @@ RSpec.describe Hanami::Action::Params do
       end
     end
 
-    context "when this feature is enabled" do
+    context "when a params schema is defined" do
       let(:action) { AllowlistedUploadDslAction.new }
 
       it "raw gets all params" do
@@ -44,12 +44,42 @@ RSpec.describe Hanami::Action::Params do
         end
       end
     end
+
+    context "when the request body is parsed (e.g. multipart)" do
+      let(:config) { Class.new(Hanami::Action).config }
+      let(:boundary) { "----WebKitFormBoundaryTEST" }
+      let(:body) {
+        [
+          "--#{boundary}",
+          'Content-Disposition: form-data; name="_csrf_token"',
+          "",
+          "abc123",
+          "--#{boundary}--"
+        ].join("\r\n")
+      }
+      let(:env) {
+        {
+          "REQUEST_METHOD" => "POST",
+          "CONTENT_TYPE" => "multipart/form-data; boundary=#{boundary}",
+          "CONTENT_LENGTH" => body.bytesize.to_s,
+          Rack::RACK_INPUT => StringIO.new(body)
+        }
+      }
+
+      it "keeps the body params under the string keys sent by the client" do
+        Hanami::Action::BodyParser.parse(env, config)
+        params = Hanami::Action::Params.new(env: env)
+
+        expect(params.raw["_csrf_token"]).to eq("abc123")
+        expect(params[:_csrf_token]).to eq("abc123")
+      end
+    end
   end
 
   describe "allowlisting" do
     let(:params) { Class.new(Hanami::Action::Params) }
 
-    context "when this feature isn't enabled" do
+    context "when no params schema is defined" do
       let(:action) { ParamsAction.new }
 
       it "creates a Params innerclass" do
@@ -97,7 +127,7 @@ RSpec.describe Hanami::Action::Params do
       end
     end
 
-    context "when this feature is enabled" do
+    context "when a params schema is defined" do
       context "with an explicit class" do
         let(:action) { AllowlistedParamsAction.new }
 


### PR DESCRIPTION
`BodyParser` deep-symbolized its output, so multipart bodies would end up in `params.raw` with symbol keys. This led to issues with handling CSRF protection, because `CSRFProtection` would looks for the token under a String key (`raw["_csrf_token"]`), so would miss the token and reject the request.

Fix this by removing the symolizing from `BodyParser`, given that `Params` is doing symbolizing anyway. This allows the `raw` to keep the string keys that `CSRFProtection` expects.

Fixes #518