### PR TITLE
Raise on unknown cache control directives, add missing ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
 
 ### Added
 
-- Support additional `Cache-Control` directives in `response.cache_control`: `:immutable`, `:must_understand`, `stale_while_revalidate:` and `stale_if_error:`. (@timriley)
+- Support additional `Cache-Control` directives in `response.cache_control`: `:immutable`, `:must_understand`, `stale_while_revalidate:` (requires a duration) and `stale_if_error:` (requires a duration). (@timriley in #522)
 
 ### Changed
 
-- `response.cache_control` now raises `ArgumentError` for unknown directives instead of silently dropping them. (@timriley)
+- `response.cache_control` raises `ArgumentError` for unknown directives instead of silently dropping them. (@timriley in #522)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
 
 ### Added
 
+- Support additional `Cache-Control` directives in `response.cache_control`: `:immutable`, `:must_understand`, `stale_while_revalidate:` and `stale_if_error:`. (@timriley)
+
 ### Changed
+
+- `response.cache_control` now raises `ArgumentError` for unknown directives instead of silently dropping them. (@timriley)
 
 ### Deprecated
 

--- a/lib/hanami/action/cache/directives.rb
+++ b/lib/hanami/action/cache/directives.rb
@@ -7,13 +7,30 @@ module Hanami
       #
       # @since 0.3.0
       # @api private
-      VALUE_DIRECTIVES      = %i[max_age s_maxage min_fresh max_stale].freeze
+      VALUE_DIRECTIVES = %i[
+        max_age
+        max_stale
+        min_fresh
+        s_maxage
+        stale_if_error
+        stale_while_revalidate
+      ].freeze
 
       # Cache-Control directives which are implicitly true
       #
       # @since 0.3.0
       # @api private
-      NON_VALUE_DIRECTIVES  = %i[public private no_cache no_store no_transform must_revalidate proxy_revalidate].freeze
+      NON_VALUE_DIRECTIVES = %i[
+        immutable
+        must_revalidate
+        must_understand
+        no_cache
+        no_store
+        no_transform
+        private
+        proxy_revalidate
+        public
+      ].freeze
 
       # Class representing value directives
       #
@@ -41,7 +58,7 @@ module Hanami
         # @since 0.3.0
         # @api private
         def valid?
-          VALUE_DIRECTIVES.include? @name
+          VALUE_DIRECTIVES.include?(@name)
         end
       end
 
@@ -71,7 +88,7 @@ module Hanami
         # @since 0.3.0
         # @api private
         def valid?
-          NON_VALUE_DIRECTIVES.include? @name
+          NON_VALUE_DIRECTIVES.include?(@name)
         end
       end
 
@@ -104,7 +121,11 @@ module Hanami
         # @since 0.3.0
         # @api private
         def <<(directive)
-          @directives << directive if directive.valid?
+          unless directive.valid?
+            raise ArgumentError.new("Unknown cache control directive: #{directive.name.inspect}")
+          end
+
+          @directives << directive
         end
 
         # @since 0.3.0

--- a/lib/hanami/action/response.rb
+++ b/lib/hanami/action/response.rb
@@ -332,12 +332,17 @@ module Hanami
 
       # Specifies the response freshness policy for HTTP caches using the `Cache-Control` header.
       #
-      # Any number of non-value directives (`:public`, `:private`, `:no_cache`, `:no_store`,
-      # `:must_revalidate`, `:proxy_revalidate`) may be passed along with a Hash of value directives
-      # (`:max_age`, `:min_stale`, `:s_max_age`).
+      # Directives come in two forms:
       #
-      # See [RFC 2616 / 14.9](http://tools.ietf.org/html/rfc2616#section-14.9.1) for more on
-      # standard cache control directives.
+      # - Non-value directives (such as `:public` or `:no_store`) are passed as bare symbols.
+      # - Value directives (such as `max_age:` or `s_maxage:`) are passed as a trailing Hash.
+      #
+      # See the `@option` entries below for the full set of supported directives. Passing an unknown
+      # directive raises an `ArgumentError`.
+      #
+      # See [MDN's Cache-Control reference][mdn] for more on the standard cache control directives.
+      #
+      # [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cache-Control
       #
       # @example
       #   # Set Cache-Control directives
@@ -349,15 +354,21 @@ module Hanami
       #   response.get_header("Cache-Control") # => "private, no-store, max-age=900"
       #
       # @param values [Array<Symbol, Hash>] values to map to `Cache-Control` directives
-      # @option values [Symbol] :public
-      # @option values [Symbol] :private
+      # @option values [Symbol] :immutable
+      # @option values [Symbol] :must_revalidate
+      # @option values [Symbol] :must_understand
       # @option values [Symbol] :no_cache
       # @option values [Symbol] :no_store
-      # @option values [Symbol] :must_validate
+      # @option values [Symbol] :no_transform
+      # @option values [Symbol] :private
       # @option values [Symbol] :proxy_revalidate
+      # @option values [Symbol] :public
       # @option values [Hash] :max_age
-      # @option values [Hash] :min_stale
-      # @option values [Hash] :s_max_age
+      # @option values [Hash] :max_stale
+      # @option values [Hash] :min_fresh
+      # @option values [Hash] :s_maxage
+      # @option values [Hash] :stale_if_error
+      # @option values [Hash] :stale_while_revalidate
       #
       # @return void
       #

--- a/spec/unit/hanami/action/cache/directives_spec.rb
+++ b/spec/unit/hanami/action/cache/directives_spec.rb
@@ -3,13 +3,18 @@
 RSpec.describe Hanami::Action::Cache::Directives do
   describe "#directives" do
     context "non value directives" do
-      it "accepts public symbol" do
-        subject = described_class.new(:public)
+      it "accepts immutable symbol" do
+        subject = described_class.new(:immutable)
         expect(subject.values.size).to eq(1)
       end
 
-      it "accepts private symbol" do
-        subject = described_class.new(:private)
+      it "accepts must_revalidate symbol" do
+        subject = described_class.new(:must_revalidate)
+        expect(subject.values.size).to eq(1)
+      end
+
+      it "accepts must_understand symbol" do
+        subject = described_class.new(:must_understand)
         expect(subject.values.size).to eq(1)
       end
 
@@ -28,8 +33,8 @@ RSpec.describe Hanami::Action::Cache::Directives do
         expect(subject.values.size).to eq(1)
       end
 
-      it "accepts must_revalidate symbol" do
-        subject = described_class.new(:must_revalidate)
+      it "accepts private symbol" do
+        subject = described_class.new(:private)
         expect(subject.values.size).to eq(1)
       end
 
@@ -38,9 +43,14 @@ RSpec.describe Hanami::Action::Cache::Directives do
         expect(subject.values.size).to eq(1)
       end
 
-      it "does not accept weird symbol" do
-        subject = described_class.new(:weird)
-        expect(subject.values.size).to eq(0)
+      it "accepts public symbol" do
+        subject = described_class.new(:public)
+        expect(subject.values.size).to eq(1)
+      end
+
+      it "raises ArgumentError for an unknown symbol" do
+        expect { described_class.new(:weird) }
+          .to raise_error(ArgumentError, "Unknown cache control directive: :weird")
       end
 
       context "multiple symbols" do
@@ -69,8 +79,8 @@ RSpec.describe Hanami::Action::Cache::Directives do
         expect(subject.values.size).to eq(1)
       end
 
-      it "accepts s_maxage symbol" do
-        subject = described_class.new(s_maxage: 600)
+      it "accepts max_stale symbol" do
+        subject = described_class.new(max_stale: 600)
         expect(subject.values.size).to eq(1)
       end
 
@@ -79,14 +89,24 @@ RSpec.describe Hanami::Action::Cache::Directives do
         expect(subject.values.size).to eq(1)
       end
 
-      it "accepts max_stale symbol" do
-        subject = described_class.new(max_stale: 600)
+      it "accepts s_maxage symbol" do
+        subject = described_class.new(s_maxage: 600)
         expect(subject.values.size).to eq(1)
       end
 
-      it "does not accept weird symbol" do
-        subject = described_class.new(weird: 600)
-        expect(subject.values.size).to eq(0)
+      it "accepts stale_if_error symbol" do
+        subject = described_class.new(stale_if_error: 600)
+        expect(subject.values.size).to eq(1)
+      end
+
+      it "accepts stale_while_revalidate symbol" do
+        subject = described_class.new(stale_while_revalidate: 600)
+        expect(subject.values.size).to eq(1)
+      end
+
+      it "raises ArgumentError for an unknown symbol" do
+        expect { described_class.new(weird: 600) }
+          .to raise_error(ArgumentError, "Unknown cache control directive: :weird")
       end
 
       context "multiple symbols" do


### PR DESCRIPTION
Previously `response.cache_control` (and the underlying Cache::Directives) silently dropped any directive it didn't recognise, so a typo or an unsupported directive vanished from the `Cache-Control` header with no feedback. Now passing an unknown directive raises an `ArgumentError`.

Also add support for several directives that were missing:

  - immutable
  - must_understand
  - stale_while_revalidate
  - stale_if_error

Update the `#cache_control` docs to describe the two directive forms, list the full supported set via @option, and point at MDN rather than the obsolete RFC 2616 link.

Fixes #520