### PR TITLE
Do not coerce session keys to strings for getters/setters

### DIFF
--- a/lib/hanami/action/request/session.rb
+++ b/lib/hanami/action/request/session.rb
@@ -14,6 +14,9 @@ module Hanami
 
         def_delegators \
           :@session,
+          :[],
+          :[]=,
+          :key?,
           :clear,
           :delete,
           :empty?,
@@ -27,18 +30,6 @@ module Hanami
 
         def initialize(session)
           @session = session
-        end
-
-        def [](key)
-          @session[key.to_s]
-        end
-
-        def []=(key, value)
-          @session[key.to_s] = value
-        end
-
-        def key?(key)
-          @session.key?(key.to_s)
         end
 
         alias_method :has_key?, :key?

--- a/spec/unit/hanami/action/csrf_protection_spec.rb
+++ b/spec/unit/hanami/action/csrf_protection_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Hanami::Action::CSRFProtection do
 
     context "Existing session" do
       let(:request) { super().merge("rack.session" => session) }
-      let(:session) { {"_csrf_token" => session_token} }
+      let(:session) { {_csrf_token: session_token} }
       let(:session_token) { "abc123" }
 
       context "matching CSRF token in request" do
@@ -130,7 +130,7 @@ RSpec.describe Hanami::Action::CSRFProtection do
 
         context "Existing session" do
           let(:request) { super().merge("rack.session" => session) }
-          let(:session) { {"_csrf_token" => session_token} }
+          let(:session) { {_csrf_token: session_token} }
           let(:session_token) { "abc123" }
 
           it "includes the existing CSRF token in the response session" do

--- a/spec/unit/hanami/action/session_spec.rb
+++ b/spec/unit/hanami/action/session_spec.rb
@@ -16,9 +16,16 @@ RSpec.describe Hanami::Action do
       expect(response.session).to eq({})
     end
 
-    it "allows value access via symbols" do
+    it "allows value access via strings" do
       action   = SessionAction.new
       response = action.call("rack.session" => {"foo" => "bar"})
+
+      expect(response.session["foo"]).to eq("bar")
+    end
+
+    it "allows value access via symbols" do
+      action   = SessionAction.new
+      response = action.call("rack.session" => {foo: "bar"})
 
       expect(response.session[:foo]).to eq("bar")
     end


### PR DESCRIPTION
I came across a bug today where I had this code in my action's test:

```ruby
  let(:params) do
    {
      book_permalink: "book-permalink",
      chapter_permalink: "chapter-permalink",
      note_id: 1,
      text: "Updated note text",
      "rack.session" => { user_id: 1 },
    }
  end
```

But then when attempting to access the session's value in the action's code:

```ruby
request.session[:user_id] => nil
```

This is because the previous implementation was stringifying keys. There wasn't a session key stored as `"user_id"` in the session, so it returns `nil`.

This PR removes the cooercing-to-string of these values. So whatever is put in there is now maintained in the data type it was insertedin.