### PR TITLE
Provide `Hanami::Action::TestHelper` class

### DIFF
--- a/lib/hanami/action/test_helper.rb
+++ b/lib/hanami/action/test_helper.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Hanami
+  class Action
+    # Testing conveniences for calling actions directly.
+    #
+    # Prepend this module in test environments only. It allows actions to be
+    # called with a bare params hash and/or a session hash, instead of a full
+    # Rack env:
+    #
+    # @example
+    #   Hanami::Action.prepend(Hanami::Action::TestHelper)
+    #
+    #   action.call(params: {id: 1}, session: {user_id: 2})
+    #
+    # @since 3.1.0
+    # @api public
+    module TestHelper
+      # @see Hanami::Action#call
+      #
+      # @since 3.1.0
+      # @api public
+      def call(env = nil, params: nil, session: nil, **rest)
+        env = params if params.is_a?(Hash) && env.nil?
+        env ||= rest
+
+        # Ensure env has REQUEST_METHOD for downstream code (e.g. Response) when
+        # actions are called with a direct params hash.
+        env[REQUEST_METHOD] ||= DEFAULT_REQUEST_METHOD
+        env[RACK_SESSION] = session if session && session_enabled?
+
+        super(env)
+      end
+    end
+  end
+end

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -391,6 +391,14 @@ class SessionAction < Hanami::Action
   end
 end
 
+class SessionActionWithTestHelper < Hanami::Action
+  include Hanami::Action::Session
+  include Hanami::Action::TestHelper
+
+  def handle(req, res)
+  end
+end
+
 class FlashAction < Hanami::Action
   include Hanami::Action::Session
 

--- a/spec/unit/hanami/action/session_spec.rb
+++ b/spec/unit/hanami/action/session_spec.rb
@@ -9,6 +9,13 @@ RSpec.describe Hanami::Action do
       expect(response.session).to eq(user_id: "23")
     end
 
+    it "accepts session from TestHelper" do
+      action   = SessionActionWithTestHelper.new
+      response = action.call(session: {user_id: "23"})
+
+      expect(response.session).to eq(user_id: "23")
+    end
+
     it "returns empty hash when it is missing" do
       action   = SessionAction.new
       response = action.call({})


### PR DESCRIPTION
This allows for a cleaner syntax for passing through params + session data in a test:

Before:

```ruby
params = {
  book_permalink: "book-permalink",
  chapter_permalink: "chapter-permalink",
  note_id: 1,
  text: "Updated note text",
  "rack.session" => { user_id: 1 },
}
action.call(params)
```

After:

```ruby
params = {
  book_permalink: "book-permalink",
  chapter_permalink: "chapter-permalink",
  note_id: 1,
  text: "Updated note text",
}
session = { user_id: 1 }
action.call(params:, session:)
```

You can opt in to this via:

```ruby
described_class.include Hanami::Action::TestHelper
```

Or via similar "global" `before` syntax with RSpec.

Helper is opt-in, and should only be used in test environments. It is not intended for use in production code.