### PR TITLE
Depend on hanami-utils 3.0.x

### DIFF
--- a/hanami-action.gemspec
+++ b/hanami-action.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.3"
 
   spec.add_runtime_dependency "rack", ">= 2.2.16"
-  spec.add_runtime_dependency "hanami-utils", "~> 3.0.0.rc"
+  spec.add_runtime_dependency "hanami-utils", "~> 3.0.0"
   spec.add_runtime_dependency "dry-configurable", "~> 1.4"
   spec.add_runtime_dependency "dry-core", "~> 1.0"
   spec.add_runtime_dependency "zeitwerk", "~> 2.6"

--- a/repo-sync.yml
+++ b/repo-sync.yml
@@ -13,7 +13,7 @@ gemspec:
   homepage: "https://hanamirb.org"
   runtime_dependencies:
     - ["rack", ">= 2.2.16"]
-    - ["hanami-utils", "~> 3.0.0.rc"]
+    - ["hanami-utils", "~> 3.0.0"]
     - ["dry-configurable", "~> 1.4"]
     - ["dry-core", "~> 1.0"]
     - ["zeitwerk", "~> 2.6"]


### PR DESCRIPTION
Fix an old 3.0.0.rc dependency left over from an earlier release.